### PR TITLE
Add ShellCommandExecutor

### DIFF
--- a/examples/ShellCommandExecutorExample.cpp
+++ b/examples/ShellCommandExecutorExample.cpp
@@ -1,0 +1,21 @@
+
+
+#include <Blast/ShellCommandExecutor.hpp>
+
+#include <iostream>
+
+
+int main(int, char**)
+{
+   std::string command = "echo \"hello shell command!\"";
+   ShellCommandExecutor shell_command_executor(command);
+
+   std::string result = shell_command_executor.execute();
+
+   std::cout << "Command: " << command << std::endl;
+   std::cout << "Returned output: " << result << std::endl;
+
+   return 0;
+}
+
+

--- a/include/Blast/ShellCommandExecutor.hpp
+++ b/include/Blast/ShellCommandExecutor.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+
+#include <string>
+
+
+class ShellCommandExecutor
+{
+private:
+   std::string command;
+
+public:
+   ShellCommandExecutor(std::string command);
+   ~ShellCommandExecutor();
+
+   std::string execute();
+};
+
+

--- a/src/ShellCommandExecutor.cpp
+++ b/src/ShellCommandExecutor.cpp
@@ -1,0 +1,40 @@
+
+
+#include <Blast/ShellCommandExecutor.hpp>
+
+#include <array>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+
+ShellCommandExecutor::ShellCommandExecutor(std::string command)
+   : command(command)
+{
+}
+
+
+ShellCommandExecutor::~ShellCommandExecutor()
+{
+}
+
+
+std::string ShellCommandExecutor::execute()
+{
+   static const int BUFFER_SIZE = 128;
+
+   std::array<char, BUFFER_SIZE> buffer;
+   std::string result;
+   std::shared_ptr<FILE> pipe(popen(command.c_str(), "r"), pclose);
+
+   if (!pipe) throw std::runtime_error("ShellCommandExecutor::execute(): Error: popen() failed.");
+
+   while (!feof(pipe.get()))
+      if (fgets(buffer.data(), BUFFER_SIZE, pipe.get()) != nullptr)
+         result += buffer.data();
+
+   return result;
+}
+
+

--- a/tests/ShellCommandExecutorTest.cpp
+++ b/tests/ShellCommandExecutorTest.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+
+#include <Blast/ShellCommandExecutor.hpp>
+
+
+#include <iostream>
+
+
+TEST(ShellCommandExecutorTest, can_be_created)
+{
+   ShellCommandExecutor shell_command_executor("ls");
+}
+
+
+TEST(ShellCommandExecutorTest, executes_a_shell_command_and_returns_the_output)
+{
+   std::string expected_string = "hello shell command!";
+   std::stringstream command;
+   command << "printf \"" << expected_string << "\"";
+
+   ShellCommandExecutor shell_command_executor(command.str());
+
+   ASSERT_EQ(expected_string, shell_command_executor.execute());
+}
+
+


### PR DESCRIPTION
`ShellCommandExecutor` is a simple class that takes a shell command, executes it, and returns the output as a string.

Naturally, this would only be used for commands that have a simple command-and-output interface.  Nevertheless, it can be incredibly useful for running system commands within a C++ program.