### PR TITLE
Add RailsInflector

### DIFF
--- a/examples/RailsInflectorExample.cpp
+++ b/examples/RailsInflectorExample.cpp
@@ -1,0 +1,43 @@
+
+
+#include <Blast/RailsInflector.hpp>
+
+#include <iostream>
+#include <vector>
+
+
+int main(int argc, char *argv[])
+{
+   std::vector<std::string> words = {
+      "tree",
+      "duck",
+      "family",
+      "mouse",
+      "mice",
+      "hamster",
+      "goose",
+      "geese",
+      "horde",
+      "data",
+   };
+
+   std::cout << "Pluralizing:" << std::endl;
+
+   for (auto &word : words)
+   {
+      Blast::RailsInflector rails_inflector(word, Blast::RailsInflector::PLURALIZE);
+      std::cout << "   " << word << ": " << rails_inflector.inflect() << std::endl;
+   }
+
+   std::cout << "Singularizing:" << std::endl;
+
+   for (auto &word : words)
+   {
+      Blast::RailsInflector rails_inflector(word, Blast::RailsInflector::SINGULARIZE);
+      std::cout << "   " << word << ": " << rails_inflector.inflect() << std::endl;
+   }
+
+   return 0;
+}
+
+

--- a/include/Blast/RailsInflector.hpp
+++ b/include/Blast/RailsInflector.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+
+#include <string>
+
+
+namespace Blast
+{
+   class RailsInflector
+   {
+      public:
+         enum inflection_operation_t
+         {
+            PLURALIZE,
+            SINGULARIZE
+         };
+
+      private:
+         std::string term;
+         inflection_operation_t inflection_operation;
+
+      public:
+         RailsInflector(std::string term, inflection_operation_t inflection_operation);
+         ~RailsInflector();
+
+         std::string inflect();
+   };
+}
+
+

--- a/src/RailsInflector.cpp
+++ b/src/RailsInflector.cpp
@@ -1,0 +1,106 @@
+
+
+#include <Blast/RailsInflector.hpp>
+
+#include <Blast/ShellCommandExecutor.hpp>
+#include <fstream>
+#include <sstream>
+
+
+static const std::string rails_inflector_ruby_source = R"END(
+begin
+  require 'active_support'
+rescue LoadError
+  print 'error: Could not load dependency "active_support"; Rails must be installed in your local system to use this feature.' and abort
+end
+
+# validate missing arguments
+print 'error: Must pass "-singularize" or "-pluralize" as the first argument and a string as the second argument' and abort if ARGV.count != 2
+
+# validate first argument
+print 'error: Must pass "-singularize" or "-pluralize" as the first argument' and abort unless %w(-pluralize -singularize).include?(ARGV[0])
+
+case ARGV[0]
+when '-singularize'
+  print ActiveSupport::Inflector.singularize(ARGV[1])
+when '-pluralize'
+  print ActiveSupport::Inflector.pluralize(ARGV[1])
+end
+)END";
+
+
+static std::string ___replace_in_string(std::string str, std::string from, std::string to)
+{
+   size_t start_pos = 0;
+   while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+      str.replace(start_pos, from.length(), to);
+      start_pos += to.length();
+   }
+
+   return str;
+}
+
+
+static std::string ___sanitize(std::string str)
+{
+   str = ___replace_in_string(str, "\\", "\\\\");
+   str = ___replace_in_string(str, "\"", "\\\"");
+
+   return str;
+}
+
+
+namespace Blast
+{
+
+
+RailsInflector::RailsInflector(std::string term, inflection_operation_t inflection_operation)
+   : term(term)
+   , inflection_operation(inflection_operation)
+{
+   if (term.empty()) throw std::runtime_error("RailsInflector::RailsInflector(): term cannot be blank");
+}
+
+
+RailsInflector::~RailsInflector()
+{
+}
+
+
+std::string RailsInflector::inflect()
+{
+   std::string tmp_output_filename = "ruby_command_output~TMP.rb";
+
+   std::ofstream file(tmp_output_filename, std::ofstream::out);
+   file << rails_inflector_ruby_source;
+   file.close();
+
+   std::string inflection_command = inflection_operation == PLURALIZE ? "-pluralize" : "-singularize";
+
+   std::string command = std::string("ruby ") + tmp_output_filename + " " + inflection_command + " \"" + ___sanitize(term) + "\"";
+   ShellCommandExecutor shell_command_executor(command);
+   std::string output = shell_command_executor.execute();
+
+   if (output.substr(0, 6) == "error:")
+   {
+      std::string returned_error_message = output.substr(7, -1);
+      std::stringstream error_message;
+      error_message
+         << "There was an error when retrieving the inflection.  The following message was returned: \""
+         << returned_error_message
+         << "\"";
+
+      throw std::runtime_error(error_message.str());
+   }
+
+   command = std::string("rm ") + tmp_output_filename;
+   ShellCommandExecutor(command).execute();
+
+   return output;
+}
+
+
+} // namespace Blast
+
+
+

--- a/tests/RailsInflectorTest.cpp
+++ b/tests/RailsInflectorTest.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+
+#include <Blast/RailsInflector.hpp>
+
+
+TEST(RailsInflectorTest, can_be_created)
+{
+   Blast::RailsInflector rails_inflector("ducks", Blast::RailsInflector::SINGULARIZE);
+}
+
+
+TEST(RailsInflectorTest, returns_the_expected_rails_inflected_singularized_form_of_a_word)
+{
+   std::vector<std::pair<std::string, std::string>> test_data_sets = {
+      { "trees", "tree" },
+      { "my favorite ducks", "my favorite duck" },
+      { "geese", "geese" },
+      { "data", "datum" },
+   };
+
+   for (auto &test_data_set : test_data_sets)
+   {
+      Blast::RailsInflector rails_inflector(std::get<0>(test_data_set), Blast::RailsInflector::SINGULARIZE);
+      ASSERT_EQ(std::get<1>(test_data_set), rails_inflector.inflect());
+   }
+}
+
+
+TEST(RailsInflectorTest, returns_the_expected_rails_inflected_pluralized_form_of_a_word)
+{
+   std::vector<std::pair<std::string, std::string>> test_data_sets = {
+      { "tree", "trees" },
+      { "my favorite duck", "my favorite ducks" },
+      { "geese", "geeses" },
+      { "datum", "data" },
+   };
+
+   for (auto &test_data_set : test_data_sets)
+   {
+      Blast::RailsInflector rails_inflector(std::get<0>(test_data_set), Blast::RailsInflector::PLURALIZE);
+      ASSERT_EQ(std::get<1>(test_data_set), rails_inflector.inflect());
+   }
+}
+
+
+TEST(RailsInflectorTest, when_initialized_with_an_empty_term_raises_an_exception)
+{
+   ASSERT_THROW(Blast::RailsInflector("", Blast::RailsInflector::PLURALIZE), std::runtime_error);
+}
+
+
+TEST(RailsInflectorTest, when_initialized_with_a_term_containing_unescaped_characters_is_sanitized)
+{
+   Blast::RailsInflector rails_inflector("\\\"duck", Blast::RailsInflector::PLURALIZE);
+   ASSERT_EQ("\\\"ducks", rails_inflector.inflect());
+}
+
+


### PR DESCRIPTION
## Accessing Rails' Inflectors

Some internal projects require access to Rails' `ActiveSupport::Inflectors`.  Particularly if you're wanting to navigate a Rails codebase and the system needs to infer the parallel model, controller, and test filenames.  Each of these have different naming schemes that can not be trivially inferred.

### Parallel Filenames for "Category"

For example, the pluralization and/or singularization of the model name `Category` would need to generate the following parallel filenames:

| Type  | Class Name | File Name |
| ---- | ---- | ---- |
| Model  | `Category`  | `category.rb`  |
| Model test  | `CategoryTest`  | `category_test.rb`  |
| Controller  | `CategoriesController`  | `categories_controller.rb`  |
| Controller test  | `CategoriesControllerTest`  | `categories_controller_test.rb`  |

Likewise, if you are currently viewing `categories_controller_test.rb` file and would like to infer the model filename, a singularization would be needed.

## Access the Inflector

In order for `RailsInflector` to work, the underlying system will need to have `ruby` and `rails` installed.  Specifically, the `active_support` gem of Rails is required.

The `RailsInflector` works by running the ruby code through a shell command and retrieving the output as a string (by using `ShellCommandExecutor`).  An alternative approach might be to [include `ruby.h` and use the interpreter within C++](https://stackoverflow.com/a/7932023/6072362), but this requires header and linker dependencies could might be more cumbersome.