### PR TITLE
Add Namespaces to CppClassGenerator

### DIFF
--- a/examples/CppClassGeneratorExample.cpp
+++ b/examples/CppClassGeneratorExample.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
       { "FSEventStreamRef", { "CoreServices/CoreServices.h" }, {}, { "-framework CoreServices" } }
    };
 
-   Blast::CppClassGenerator class_generator("User", {
+   Blast::CppClassGenerator class_generator("User", { "MyProject" }, {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_static, bool is_constructor_argument, bool has_getter, bool has_setter
          { "int", "id", "last_id++", false, false, true, false },
          { "std::string", "name", "\"[unnamed]\"", false, false, true, true },
@@ -31,12 +31,10 @@ int main(int argc, char **argv)
       symbol_dependencies
    );
 
-   class_generator.constructor_declaration_elements();
-   class_generator.constructor_definition_elements();
    std::cout << "////////// header file ///////////" << std::endl;
    std::cout << class_generator.generate_header_file_content();
    std::cout << "////////// source file ///////////" << std::endl;
-   std::cout << class_generator.generate_source_file_content("Blast");
+   std::cout << class_generator.generate_source_file_content("MyProject");
 
    return 0;
 }

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -34,6 +34,9 @@ namespace Blast
 
       bool has_namespaces();
 
+      std::string private_scope_specifier(int indent_level=0);
+      std::string public_scope_specifier(int indent_level=0);
+      std::string protected_scope_specifier(int indent_level=0);
       std::string namespaces_scope_opening(bool indented);
       std::string namespaces_scope_closing(bool indented, bool include_comment=false);
       std::string class_declaration_opener(int indent_level=0);

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -38,7 +38,7 @@ namespace Blast
       std::string public_scope_specifier(int indent_level=0);
       std::string protected_scope_specifier(int indent_level=0);
       std::string namespaces_scope_opening(bool indented);
-      std::string namespaces_scope_closing(bool indented, bool include_comment=false);
+      std::string namespaces_scope_closer(bool indented, bool include_comment=false);
       std::string class_declaration_opener(int indent_level=0);
       std::string class_declaration_closer(int indent_level=0);
       std::string header_filename();

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -34,6 +34,8 @@ namespace Blast
 
       bool has_namespaces();
 
+      std::string namespaces_scope_opening(bool indented);
+      std::string namespaces_scope_closing(bool indented);
       std::string header_filename();
       std::string source_filename();
       std::string header_include_directive(std::string project_name_camelcase);

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -13,11 +13,12 @@ namespace Blast
    {
    private:
       std::string class_name;
+      std::vector<std::string> namespaces;
       std::vector<Blast::ClassAttributeProperties> attribute_properties;
       std::vector<Blast::SymbolDependencies> symbol_dependencies;
 
    public:
-      CppClassGenerator(std::string class_name="UnnamedClass", std::vector<ClassAttributeProperties> attribute_properties={}, std::vector<Blast::SymbolDependencies> symbol_dependencies={});
+      CppClassGenerator(std::string class_name="UnnamedClass", std::vector<std::string> namespaces={}, std::vector<ClassAttributeProperties> attribute_properties={}, std::vector<Blast::SymbolDependencies> symbol_dependencies={});
       ~CppClassGenerator();
 
       std::vector<ClassAttributeProperties> &get_class_attribute_properties_ref();
@@ -30,6 +31,8 @@ namespace Blast
       void set_class_name(std::string class_name);
 
       std::string get_class_name();
+
+      bool has_namespaces();
 
       std::string header_filename();
       std::string source_filename();

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -35,7 +35,9 @@ namespace Blast
       bool has_namespaces();
 
       std::string namespaces_scope_opening(bool indented);
-      std::string namespaces_scope_closing(bool indented);
+      std::string namespaces_scope_closing(bool indented, bool include_comment=false);
+      std::string class_declaration_opener(int indent_level=0);
+      std::string class_declaration_closer(int indent_level=0);
       std::string header_filename();
       std::string source_filename();
       std::string header_include_directive(std::string project_name_camelcase);

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -37,7 +37,7 @@ namespace Blast
       std::string private_scope_specifier(int indent_level=0);
       std::string public_scope_specifier(int indent_level=0);
       std::string protected_scope_specifier(int indent_level=0);
-      std::string namespaces_scope_opening(bool indented);
+      std::string namespaces_scope_opener(bool indented);
       std::string namespaces_scope_closer(bool indented, bool include_comment=false);
       std::string class_declaration_opener(int indent_level=0);
       std::string class_declaration_closer(int indent_level=0);

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -130,7 +130,7 @@ std::string CppClassGenerator::get_class_name()
 }
 
 
-std::string CppClassGenerator::namespaces_scope_opening(bool indented)
+std::string CppClassGenerator::namespaces_scope_opener(bool indented)
 {
    std::stringstream result;
    int indentation_level = 0;
@@ -361,7 +361,7 @@ NAMESPACES_CLOSER
 
    std::string result = source_file_template;
 
-   __replace(result, "NAMESPACES_OPENER", namespaces_scope_opening(false));
+   __replace(result, "NAMESPACES_OPENER", namespaces_scope_opener(false));
    __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closer(false));
    __replace(result, "CLASS_HEADER_INCLUDE_DIRECTIVE\n", header_include_directive(project_name_camelcase));
    __replace(result, "HEADER_FILENAME", header_filename());
@@ -403,7 +403,7 @@ NAMESPACES_CLOSER
 
    int required_namespace_indentation_levels = namespaces.size();
 
-   __replace(result, "NAMESPACES_OPENER\n", namespaces_scope_opening(true));
+   __replace(result, "NAMESPACES_OPENER\n", namespaces_scope_opener(true));
    __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closer(true, false));
    __replace(result, "DEPENDENCY_INCLUDE_DIRECTIVES", dependency_include_directives());
    __replace(result, "CLASS_NAME", class_name);

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -34,8 +34,9 @@ namespace Blast
 {
 
 
-CppClassGenerator::CppClassGenerator(std::string class_name, std::vector<ClassAttributeProperties> attribute_properties, std::vector<Blast::SymbolDependencies> symbol_dependencies)
+CppClassGenerator::CppClassGenerator(std::string class_name, std::vector<std::string> namespaces, std::vector<ClassAttributeProperties> attribute_properties, std::vector<Blast::SymbolDependencies> symbol_dependencies)
    : class_name(class_name)
+   , namespaces(namespaces)
    , attribute_properties(attribute_properties)
    , symbol_dependencies(symbol_dependencies)
 {
@@ -90,6 +91,12 @@ std::vector<std::string> CppClassGenerator::initialization_list_elements()
 void CppClassGenerator::set_class_name(std::string class_name)
 {
    this->class_name = class_name;
+}
+
+
+bool CppClassGenerator::has_namespaces()
+{
+   return !namespaces.empty();
 }
 
 

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -146,7 +146,7 @@ std::string CppClassGenerator::namespaces_scope_opening(bool indented)
 }
 
 
-std::string CppClassGenerator::namespaces_scope_closing(bool indented, bool include_comment)
+std::string CppClassGenerator::namespaces_scope_closer(bool indented, bool include_comment)
 {
    std::stringstream result;
    for (int i=namespaces.size()-1; i>=0; i--)
@@ -362,7 +362,7 @@ NAMESPACES_CLOSER
    std::string result = source_file_template;
 
    __replace(result, "NAMESPACES_OPENER", namespaces_scope_opening(false));
-   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closing(false));
+   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closer(false));
    __replace(result, "CLASS_HEADER_INCLUDE_DIRECTIVE\n", header_include_directive(project_name_camelcase));
    __replace(result, "HEADER_FILENAME", header_filename());
    __replace(result, "CONSTRUCTOR\n", constructor_definition(0));
@@ -404,7 +404,7 @@ NAMESPACES_CLOSER
    int required_namespace_indentation_levels = namespaces.size();
 
    __replace(result, "NAMESPACES_OPENER\n", namespaces_scope_opening(true));
-   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closing(true, false));
+   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closer(true, false));
    __replace(result, "DEPENDENCY_INCLUDE_DIRECTIVES", dependency_include_directives());
    __replace(result, "CLASS_NAME", class_name);
    __replace(result, "CONSTRUCTOR\n", constructor_declaration(required_namespace_indentation_levels + 1));

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -100,6 +100,30 @@ bool CppClassGenerator::has_namespaces()
 }
 
 
+std::string CppClassGenerator::private_scope_specifier(int indent_level)
+{
+   std::stringstream result;
+   result << std::string(3*indent_level, ' ') << "private:\n";
+   return result.str();
+}
+
+
+std::string CppClassGenerator::public_scope_specifier(int indent_level)
+{
+   std::stringstream result;
+   result << std::string(3*indent_level, ' ') << "public:\n";
+   return result.str();
+}
+
+
+std::string CppClassGenerator::protected_scope_specifier(int indent_level)
+{
+   std::stringstream result;
+   result << std::string(3*indent_level, ' ') << "protected:\n";
+   return result.str();
+}
+
+
 std::string CppClassGenerator::get_class_name()
 {
    return class_name;
@@ -148,7 +172,7 @@ std::string CppClassGenerator::class_declaration_opener(int indent_level)
 std::string CppClassGenerator::class_declaration_closer(int indent_level)
 {
    std::stringstream result;
-   result << std::string(3*indent_level, ' ') << "};";
+   result << std::string(3*indent_level, ' ') << "};\n";
    return result.str();
 }
 
@@ -338,7 +362,7 @@ NAMESPACES_CLOSER
    std::string result = source_file_template;
 
    __replace(result, "NAMESPACES_OPENER", namespaces_scope_opening(false));
-   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closing(false, true));
+   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closing(false));
    __replace(result, "CLASS_HEADER_INCLUDE_DIRECTIVE\n", header_include_directive(project_name_camelcase));
    __replace(result, "HEADER_FILENAME", header_filename());
    __replace(result, "CONSTRUCTOR\n", constructor_definition(0));
@@ -359,10 +383,10 @@ DEPENDENCY_INCLUDE_DIRECTIVES
 
 NAMESPACES_OPENER
 CLASS_DECLARATION_OPENER
-private:
+PRIVATE_SCOPE_SPECIFIER
 PROPERTIES
 
-public:
+PUBLIC_SCOPE_SPECIFIER
 CONSTRUCTOR
 DESTRUCTOR
 
@@ -380,7 +404,7 @@ NAMESPACES_CLOSER
    int required_namespace_indentation_levels = namespaces.size();
 
    __replace(result, "NAMESPACES_OPENER\n", namespaces_scope_opening(true));
-   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closing(true, true));
+   __replace(result, "NAMESPACES_CLOSER", namespaces_scope_closing(true, false));
    __replace(result, "DEPENDENCY_INCLUDE_DIRECTIVES", dependency_include_directives());
    __replace(result, "CLASS_NAME", class_name);
    __replace(result, "CONSTRUCTOR\n", constructor_declaration(required_namespace_indentation_levels + 1));
@@ -389,7 +413,9 @@ NAMESPACES_CLOSER
    __replace(result, "SETTER_FUNCTIONS\n", setter_function_declarations(required_namespace_indentation_levels + 1));
    __replace(result, "GETTER_FUNCTIONS\n", getter_function_declarations(required_namespace_indentation_levels + 1));
    __replace(result, "CLASS_DECLARATION_OPENER\n", class_declaration_opener(required_namespace_indentation_levels));
-   __replace(result, "CLASS_DECLARATION_CLOSER", class_declaration_closer(required_namespace_indentation_levels));
+   __replace(result, "CLASS_DECLARATION_CLOSER\n", class_declaration_closer(required_namespace_indentation_levels));
+   __replace(result, "PRIVATE_SCOPE_SPECIFIER\n", private_scope_specifier(required_namespace_indentation_levels));
+   __replace(result, "PUBLIC_SCOPE_SPECIFIER\n", public_scope_specifier(required_namespace_indentation_levels));
 
    return result;
 }

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -106,6 +106,35 @@ std::string CppClassGenerator::get_class_name()
 }
 
 
+std::string CppClassGenerator::namespaces_scope_opening(bool indented)
+{
+   std::stringstream result;
+   int indentation_level = 0;
+   for (auto &n : namespaces)
+   {
+      if (indented) result << std::string(3*indentation_level, ' ');
+      result << "namespace " << n << "\n";
+      if (indented) result << std::string(3*indentation_level, ' ');
+      result << "{\n";
+      if (indented) indentation_level++;
+   }
+   return result.str();
+}
+
+
+std::string CppClassGenerator::namespaces_scope_closing(bool indented)
+{
+   std::stringstream result;
+   for (int i=namespaces.size()-1; i>=0; i--)
+   {
+      std::string &n = namespaces[i];
+      if (indented) result << std::string(3*i, ' ');
+      result << "} // namespace " << n << "\n";
+   }
+   return result.str();
+}
+
+
 std::string CppClassGenerator::header_filename()
 {
    std::stringstream result;

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -109,18 +109,17 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_stri
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_returns_en_empty_string)
-{
-   ASSERT_EQ("", class_generator_fixture.namespaces_scope_opening(true));
-   ASSERT_EQ("", class_generator_fixture.namespaces_scope_opening(false));
-}
-
-
 TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_with_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
    std::string expected_opening_namespace_statement = "namespace Fullscore\n{\n   namespace Action\n   {\n      namespace Transform\n      {\n";
    ASSERT_EQ(expected_opening_namespace_statement, class_generator.namespaces_scope_opening(true));
+}
+
+
+TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_returns_en_empty_string)
+{
+   ASSERT_EQ("", class_generator_fixture.namespaces_scope_opening(true));
 }
 
 
@@ -150,7 +149,6 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_closing__can_optionally_include_c
 
 TEST_F(CppClassGeneratorTest, namespaces_scope_closing__without_namespaces_returns_en_empty_string)
 {
-   ASSERT_EQ("", class_generator_fixture.namespaces_scope_closing(true));
    ASSERT_EQ("", class_generator_fixture.namespaces_scope_closing(false));
 }
 

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -80,6 +80,38 @@ TEST_F(CppClassGeneratorTest, has_namespaces__returns_false_if_namespaces_are_pr
 }
 
 
+TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_without_indentations)
+{
+   Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
+   std::string expected_opening_namespace_statement = "namespace Fullscore\n{\nnamespace Action\n{\nnamespace Transform\n{\n";
+   ASSERT_EQ(expected_opening_namespace_statement, class_generator.namespaces_scope_opening(false));
+}
+
+
+TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_with_indentations)
+{
+   Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
+   std::string expected_opening_namespace_statement = "namespace Fullscore\n{\n   namespace Action\n   {\n      namespace Transform\n      {\n";
+   ASSERT_EQ(expected_opening_namespace_statement, class_generator.namespaces_scope_opening(true));
+}
+
+
+TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_without_indentations)
+{
+   Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
+   std::string expected_closing_namespace_statement = "} // namespace Transform\n} // namespace Action\n} // namespace Fullscore\n";
+   ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(false));
+}
+
+
+TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_with_indentations)
+{
+   Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
+   std::string expected_closing_namespace_statement = "      } // namespace Transform\n   } // namespace Action\n} // namespace Fullscore\n";
+   ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(true));
+}
+
+
 TEST_F(CppClassGeneratorTest, get_class_attribute_properties_ref__returns_a_reference_to_the_class_attribute_properties)
 {
    // TODO

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -123,33 +123,33 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_retur
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_without_nested_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_closer__returns_a_formatted_string_of_the_closer_namespace_statement_without_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
-   std::string expected_closing_namespace_statement = "}\n}\n}\n";
-   ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(false));
+   std::string expected_closer_namespace_statement = "}\n}\n}\n";
+   ASSERT_EQ(expected_closer_namespace_statement, class_generator.namespaces_scope_closer(false));
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_with_nested_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_closer__returns_a_formatted_string_of_the_closer_namespace_statement_with_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
-   std::string expected_closing_namespace_statement = "      }\n   }\n}\n";
-   ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(true));
+   std::string expected_closer_namespace_statement = "      }\n   }\n}\n";
+   ASSERT_EQ(expected_closer_namespace_statement, class_generator.namespaces_scope_closer(true));
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_closing__can_optionally_include_closing_comment)
+TEST_F(CppClassGeneratorTest, namespaces_scope_closer__can_optionally_include_closer_comment)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
-   std::string expected_closing_namespace_statement = "      } // namespace Transform\n   } // namespace Action\n} // namespace Fullscore\n";
-   ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(true, true));
+   std::string expected_closer_namespace_statement = "      } // namespace Transform\n   } // namespace Action\n} // namespace Fullscore\n";
+   ASSERT_EQ(expected_closer_namespace_statement, class_generator.namespaces_scope_closer(true, true));
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_closing__without_namespaces_returns_an_empty_string)
+TEST_F(CppClassGeneratorTest, namespaces_scope_closer__without_namespaces_returns_an_empty_string)
 {
-   ASSERT_EQ("", class_generator_fixture.namespaces_scope_closing(false));
+   ASSERT_EQ("", class_generator_fixture.namespaces_scope_closer(false));
 }
 
 

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -80,6 +80,27 @@ TEST_F(CppClassGeneratorTest, has_namespaces__returns_false_if_namespaces_are_pr
 }
 
 
+TEST_F(CppClassGeneratorTest, private_scope_specifier__returns_a_string_formatted_with_the_appropriate_scope_specifier)
+{
+   std::string expected_scope_specifier = "   private:\n";
+   ASSERT_EQ(expected_scope_specifier, class_generator_fixture.private_scope_specifier(1));
+}
+
+
+TEST_F(CppClassGeneratorTest, public_scope_specifier__returns_a_string_formatted_with_the_appropriate_scope_specifier)
+{
+   std::string expected_scope_specifier = "   public:\n";
+   ASSERT_EQ(expected_scope_specifier, class_generator_fixture.public_scope_specifier(1));
+}
+
+
+TEST_F(CppClassGeneratorTest, protected_scope_specifier__returns_a_string_formatted_with_the_appropriate_scope_specifier)
+{
+   std::string expected_scope_specifier = "   protected:\n";
+   ASSERT_EQ(expected_scope_specifier, class_generator_fixture.protected_scope_specifier(1));
+}
+
+
 TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_without_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
@@ -145,7 +166,7 @@ TEST_F(CppClassGeneratorTest, class_declaration_opener__returns_a_formatted_stri
 TEST_F(CppClassGeneratorTest, class_declaration_closer_returns_a_formatted_string_of_the_classes_closing_statemet)
 {
    Blast::CppClassGenerator class_generator("Happiness");
-   std::string expected_closing_class_statement = "   };";
+   std::string expected_closing_class_statement = "   };\n";
    ASSERT_EQ(expected_closing_class_statement, class_generator.class_declaration_closer(1));
 }
 

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -88,6 +88,13 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_stri
 }
 
 
+TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_returns_en_empty_string)
+{
+   ASSERT_EQ("", class_generator_fixture.namespaces_scope_opening(true));
+   ASSERT_EQ("", class_generator_fixture.namespaces_scope_opening(false));
+}
+
+
 TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_with_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
@@ -99,7 +106,7 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_stri
 TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_without_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
-   std::string expected_closing_namespace_statement = "} // namespace Transform\n} // namespace Action\n} // namespace Fullscore\n";
+   std::string expected_closing_namespace_statement = "}\n}\n}\n";
    ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(false));
 }
 
@@ -107,8 +114,39 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_stri
 TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_with_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
-   std::string expected_closing_namespace_statement = "      } // namespace Transform\n   } // namespace Action\n} // namespace Fullscore\n";
+   std::string expected_closing_namespace_statement = "      }\n   }\n}\n";
    ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(true));
+}
+
+
+TEST_F(CppClassGeneratorTest, namespaces_scope_closing__can_optionally_include_closing_comment)
+{
+   Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
+   std::string expected_closing_namespace_statement = "      } // namespace Transform\n   } // namespace Action\n} // namespace Fullscore\n";
+   ASSERT_EQ(expected_closing_namespace_statement, class_generator.namespaces_scope_closing(true, true));
+}
+
+
+TEST_F(CppClassGeneratorTest, namespaces_scope_closing__without_namespaces_returns_en_empty_string)
+{
+   ASSERT_EQ("", class_generator_fixture.namespaces_scope_closing(true));
+   ASSERT_EQ("", class_generator_fixture.namespaces_scope_closing(false));
+}
+
+
+TEST_F(CppClassGeneratorTest, class_declaration_opener__returns_a_formatted_string_of_the_classes_opening_statement)
+{
+   Blast::CppClassGenerator class_generator("Happiness");
+   std::string expected_opening_class_statement = "   class Happiness\n   {\n";
+   ASSERT_EQ(expected_opening_class_statement, class_generator.class_declaration_opener(1));
+}
+
+
+TEST_F(CppClassGeneratorTest, class_declaration_closer_returns_a_formatted_string_of_the_classes_closing_statemet)
+{
+   Blast::CppClassGenerator class_generator("Happiness");
+   std::string expected_closing_class_statement = "   };";
+   ASSERT_EQ(expected_closing_class_statement, class_generator.class_declaration_closer(1));
 }
 
 

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -117,7 +117,7 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_stri
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_returns_en_empty_string)
+TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_returns_an_empty_string)
 {
    ASSERT_EQ("", class_generator_fixture.namespaces_scope_opening(true));
 }
@@ -147,7 +147,7 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_closing__can_optionally_include_c
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_closing__without_namespaces_returns_en_empty_string)
+TEST_F(CppClassGeneratorTest, namespaces_scope_closing__without_namespaces_returns_an_empty_string)
 {
    ASSERT_EQ("", class_generator_fixture.namespaces_scope_closing(false));
 }

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -73,7 +73,7 @@ TEST_F(CppClassGeneratorTest, has_namespaces__returns_true_if_namespaces_are_pre
 }
 
 
-TEST_F(CppClassGeneratorTest, has_namespaces__returns_false_if_namespaces_are_present)
+TEST_F(CppClassGeneratorTest, has_namespaces__returns_false_if_namespaces_are_not_present)
 {
    Blast::CppClassGenerator class_generator("User");
    ASSERT_FALSE(class_generator.has_namespaces());

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -14,7 +14,7 @@ protected:
 
    virtual void SetUp()
    {
-      class_generator_fixture = Blast::CppClassGenerator("User", {
+      class_generator_fixture = Blast::CppClassGenerator("User", {}, {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_constructor_parameter, bool has_getter, bool has_setter
          { "int", "id", "last_id++", false, false, true, false },
          { "std::string", "name", "\"[unnamed]\"", false, true, true, true },
@@ -44,6 +44,7 @@ TEST_F(CppClassGeneratorTest, without_arguments_sets_the_expected_default_values
    //std::vector<Blast::SymbolDependencies> expected_symbol_dependencies = {};
 
    ASSERT_EQ("UnnamedClass", class_generator.get_class_name());
+   ASSERT_FALSE(class_generator.has_namespaces());
    //ASSERT_EQ(expected_class_attribute_properties, class_generator.get_class_attribute_properties_ref());
    //ASSERT_EQ(expected_symbol_dependencies, class_generator.get_symbol_dependencies_ref());
 }
@@ -59,6 +60,23 @@ TEST_F(CppClassGeneratorTest, can_get_and_set_the_class_name)
    ASSERT_EQ("Animal", class_generator.get_class_name());
    class_generator.set_class_name("ClassAttributeProperties");
    ASSERT_EQ("ClassAttributeProperties", class_generator.get_class_name());
+}
+
+
+TEST_F(CppClassGeneratorTest, has_namespaces__returns_true_if_namespaces_are_present)
+{
+   Blast::CppClassGenerator class_generator1("CppClassGenerator", { "Blast" });
+   ASSERT_TRUE(class_generator1.has_namespaces());
+
+   Blast::CppClassGenerator class_generator2("Ascend", { "Fullscore", "Action", "Transform" });
+   ASSERT_TRUE(class_generator2.has_namespaces());
+}
+
+
+TEST_F(CppClassGeneratorTest, has_namespaces__returns_false_if_namespaces_are_present)
+{
+   Blast::CppClassGenerator class_generator("User");
+   ASSERT_FALSE(class_generator.has_namespaces());
 }
 
 
@@ -136,7 +154,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_d
       { "Blast::DiceRoller", { "Blast/DiceRoller.hpp" } },
    };
 
-   class_generator_fixture = Blast::CppClassGenerator("User", {
+   class_generator_fixture = Blast::CppClassGenerator("User", {}, {
          { "std::string", "name", "\"[unnamed]\"", false, true, true, true },
          { "Blast::DiceRoller", "dice_roller", "{}", false, true, true, true },
       },
@@ -155,7 +173,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencie
       { "float" },
    };
 
-   class_generator_fixture = Blast::CppClassGenerator("User", {
+   class_generator_fixture = Blast::CppClassGenerator("User", {}, {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_constructor_parameter, bool has_getter, bool has_setter
          { "int", "num_sides", "0", false, false, true, false },
          { "float", "radius", "6.0f", false, true, true, true },
@@ -169,7 +187,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencie
 
 TEST_F(CppClassGeneratorTest, dependency_include_directives__when_a_symbol_dependency_is_not_defined_raises_an_exception)
 {
-   class_generator_fixture = Blast::CppClassGenerator("User", {
+   class_generator_fixture = Blast::CppClassGenerator("User", {}, {
          { "undefined_symbol", "foofoo", "\"foobar\"", false, false, true, false },
       }
    );

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -101,7 +101,7 @@ TEST_F(CppClassGeneratorTest, protected_scope_specifier__returns_a_string_format
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_without_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_without_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
    std::string expected_opening_namespace_statement = "namespace Fullscore\n{\nnamespace Action\n{\nnamespace Transform\n{\n";
@@ -116,7 +116,7 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_retur
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_with_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_with_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
    std::string expected_opening_namespace_statement = "namespace Fullscore\n{\n   namespace Action\n   {\n      namespace Transform\n      {\n";
@@ -124,7 +124,7 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_stri
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_without_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_without_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
    std::string expected_closing_namespace_statement = "}\n}\n}\n";
@@ -132,7 +132,7 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_stri
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_with_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_closing__returns_a_formatted_string_of_the_closing_namespace_statement_with_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
    std::string expected_closing_namespace_statement = "      }\n   }\n}\n";

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -101,25 +101,25 @@ TEST_F(CppClassGeneratorTest, protected_scope_specifier__returns_a_string_format
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_without_nested_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_opener__returns_a_formatted_string_of_the_opener_namespace_statement_without_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
-   std::string expected_opening_namespace_statement = "namespace Fullscore\n{\nnamespace Action\n{\nnamespace Transform\n{\n";
-   ASSERT_EQ(expected_opening_namespace_statement, class_generator.namespaces_scope_opening(false));
+   std::string expected_opener_namespace_statement = "namespace Fullscore\n{\nnamespace Action\n{\nnamespace Transform\n{\n";
+   ASSERT_EQ(expected_opener_namespace_statement, class_generator.namespaces_scope_opener(false));
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_opening__returns_a_formatted_string_of_the_opening_namespace_statement_with_nested_indentations)
+TEST_F(CppClassGeneratorTest, namespaces_scope_opener__returns_a_formatted_string_of_the_opener_namespace_statement_with_nested_indentations)
 {
    Blast::CppClassGenerator class_generator("Ascend", { "Fullscore", "Action", "Transform" });
-   std::string expected_opening_namespace_statement = "namespace Fullscore\n{\n   namespace Action\n   {\n      namespace Transform\n      {\n";
-   ASSERT_EQ(expected_opening_namespace_statement, class_generator.namespaces_scope_opening(true));
+   std::string expected_opener_namespace_statement = "namespace Fullscore\n{\n   namespace Action\n   {\n      namespace Transform\n      {\n";
+   ASSERT_EQ(expected_opener_namespace_statement, class_generator.namespaces_scope_opener(true));
 }
 
 
-TEST_F(CppClassGeneratorTest, namespaces_scope_opening__without_namespaces_returns_an_empty_string)
+TEST_F(CppClassGeneratorTest, namespaces_scope_opener__without_namespaces_returns_an_empty_string)
 {
-   ASSERT_EQ("", class_generator_fixture.namespaces_scope_opening(true));
+   ASSERT_EQ("", class_generator_fixture.namespaces_scope_opener(true));
 }
 
 
@@ -153,11 +153,11 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_closer__without_namespaces_return
 }
 
 
-TEST_F(CppClassGeneratorTest, class_declaration_opener__returns_a_formatted_string_of_the_classes_opening_statement)
+TEST_F(CppClassGeneratorTest, class_declaration_opener__returns_a_formatted_string_of_the_classes_opener_statement)
 {
    Blast::CppClassGenerator class_generator("Happiness");
-   std::string expected_opening_class_statement = "   class Happiness\n   {\n";
-   ASSERT_EQ(expected_opening_class_statement, class_generator.class_declaration_opener(1));
+   std::string expected_class_opener_statement = "   class Happiness\n   {\n";
+   ASSERT_EQ(expected_class_opener_statement, class_generator.class_declaration_opener(1));
 }
 
 


### PR DESCRIPTION
## Namespaces

Until this PR, generated class can only exist in the global scope.  However, most classes and projects should be scoped to a namespace.   This PR enables that by adding a `std::vector<std::string> namespaces` parameter to the `CppClassGenerator`, and formats the output accordingly.