### PR TITLE
Enable Derived Classes in CppClassGenerator

### DIFF
--- a/examples/CppClassGeneratorExample.cpp
+++ b/examples/CppClassGeneratorExample.cpp
@@ -20,7 +20,10 @@ int main(int argc, char **argv)
       { "FSEventStreamRef", { "CoreServices/CoreServices.h" }, {}, { "-framework CoreServices" } }
    };
 
-   Blast::CppClassGenerator class_generator("User", { "MyProject" }, {
+   Blast::CppClassGenerator class_generator("Kitten",
+      { "MyProject" },
+      { { "Animal", "\"Kitten\"" } },
+      {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_static, bool is_constructor_argument, bool has_getter, bool has_setter
          { "int", "id", "last_id++", false, false, true, false },
          { "std::string", "name", "\"[unnamed]\"", false, false, true, true },

--- a/examples/CppClassGeneratorExample.cpp
+++ b/examples/CppClassGeneratorExample.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
       { "std::stringstream", { "sstream" } },
       { "std::cout", { "iostream" } },
       // some more complex examples
-      { "ALLEGRO_BITMAP", { "allegro5/allegro.h" }, { "~/Repos/username/allegro5/include" }, { "-lallegro" } },
+      { "ALLEGRO_BITMAP*", { "allegro5/allegro.h" }, { "~/Repos/username/allegro5/include" }, { "-lallegro" } },
       { "al_get_font_line_height", { "allegro5/allegro.h", "allegro5/allegro_font.h" }, { "~/Repos/username/allegro5/include" }, { "-lallegro_font" } },
       { "FSEventStreamRef", { "CoreServices/CoreServices.h" }, {}, { "-framework CoreServices" } }
    };
@@ -27,9 +27,8 @@ int main(int argc, char **argv)
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_static, bool is_constructor_argument, bool has_getter, bool has_setter
          { "int", "id", "last_id++", false, false, true, false },
          { "std::string", "name", "\"[unnamed]\"", false, false, true, true },
-         { "std::string", "type", "\"[jntyped]\"", false, true, true, true },
          { "std::vector<std::string>", "typeo", "{}", false, true, true, true },
-         { "ALLEGRO_BITMAP", "bmp", "\"[untyped]\"", false, true, true, true },
+         { "ALLEGRO_BITMAP*", "bmp", "nullptr", false, true, true, true },
       },
       symbol_dependencies
    );

--- a/examples/ParentClassPropertiesExample.cpp
+++ b/examples/ParentClassPropertiesExample.cpp
@@ -1,0 +1,19 @@
+
+
+#include <Blast/ParentClassProperties.hpp>
+
+#include <iostream>
+
+
+int main(int argc, char **argv)
+{
+   Blast::ParentClassProperties parent_class_properties("Animal", "\"Dog\"", "public");
+
+   std::cout << "class name: " << parent_class_properties.get_class_name() << std::endl;
+   std::cout << "scope specifier: " << parent_class_properties.get_scope_specifier() << std::endl;
+   std::cout << "constructor arguments: " << parent_class_properties.get_constructor_arguments() << std::endl;
+
+   return 0;
+}
+
+

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -29,6 +29,7 @@ namespace Blast
       std::vector<std::string> constructor_declaration_elements();
       std::vector<std::string> constructor_definition_elements();
       std::vector<std::string> initialization_list_elements();
+      std::vector<std::string> class_declaration_opener_inheritence_elements();
 
       void set_class_name(std::string class_name);
 
@@ -42,6 +43,7 @@ namespace Blast
       std::string protected_scope_specifier(int indent_level=0);
       std::string namespaces_scope_opener(bool indented);
       std::string namespaces_scope_closer(bool indented, bool include_comment=false);
+      std::string class_declaration_inheritence_list();
       std::string class_declaration_opener(int indent_level=0);
       std::string class_declaration_closer(int indent_level=0);
       std::string header_filename();

--- a/include/Blast/CppClassGenerator.hpp
+++ b/include/Blast/CppClassGenerator.hpp
@@ -2,6 +2,7 @@
 
 
 #include <Blast/ClassAttributeProperties.hpp>
+#include <Blast/ParentClassProperties.hpp>
 #include <Blast/SymbolDependencies.hpp>
 #include <string>
 #include <vector>
@@ -14,11 +15,12 @@ namespace Blast
    private:
       std::string class_name;
       std::vector<std::string> namespaces;
+      std::vector<Blast::ParentClassProperties> parent_classes_properties;
       std::vector<Blast::ClassAttributeProperties> attribute_properties;
       std::vector<Blast::SymbolDependencies> symbol_dependencies;
 
    public:
-      CppClassGenerator(std::string class_name="UnnamedClass", std::vector<std::string> namespaces={}, std::vector<ClassAttributeProperties> attribute_properties={}, std::vector<Blast::SymbolDependencies> symbol_dependencies={});
+      CppClassGenerator(std::string class_name="UnnamedClass", std::vector<std::string> namespaces={}, std::vector<Blast::ParentClassProperties> parent_classes_properties={}, std::vector<ClassAttributeProperties> attribute_properties={}, std::vector<Blast::SymbolDependencies> symbol_dependencies={});
       ~CppClassGenerator();
 
       std::vector<ClassAttributeProperties> &get_class_attribute_properties_ref();
@@ -32,6 +34,7 @@ namespace Blast
 
       std::string get_class_name();
 
+      bool has_parent_classes();
       bool has_namespaces();
 
       std::string private_scope_specifier(int indent_level=0);

--- a/include/Blast/ParentClassProperties.hpp
+++ b/include/Blast/ParentClassProperties.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+
+#include <string>
+#include <vector>
+
+
+namespace Blast
+{
+   class ParentClassProperties
+   {
+   private:
+      bool __validate_scope_specifier(bool raise_on_error);
+
+      std::string class_name;
+      std::string constructor_arguments;
+      std::string scope_specifier;
+
+   public:
+      ParentClassProperties(std::string class_name="", std::string constructor_arguments="", std::string scope_specifier="public");
+      ~ParentClassProperties();
+
+      void set_class_name(std::string class_name);
+      void set_constructor_arguments(std::string constructor_arguments);
+      void set_scope_specifier(std::string scope_specifier);
+
+      std::string get_class_name();
+      std::string get_constructor_arguments();
+      std::string get_scope_specifier();
+   };
+}
+
+

--- a/include/Blast/ParentClassProperties.hpp
+++ b/include/Blast/ParentClassProperties.hpp
@@ -28,6 +28,7 @@ namespace Blast
       std::string get_constructor_arguments();
       std::string get_scope_specifier();
 
+      std::string as_class_inheritence_declaration();
       std::string as_argument_in_initialization_list();
    };
 }

--- a/include/Blast/ParentClassProperties.hpp
+++ b/include/Blast/ParentClassProperties.hpp
@@ -27,6 +27,8 @@ namespace Blast
       std::string get_class_name();
       std::string get_constructor_arguments();
       std::string get_scope_specifier();
+
+      std::string as_argument_in_initialization_list();
    };
 }
 

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -34,9 +34,10 @@ namespace Blast
 {
 
 
-CppClassGenerator::CppClassGenerator(std::string class_name, std::vector<std::string> namespaces, std::vector<ClassAttributeProperties> attribute_properties, std::vector<Blast::SymbolDependencies> symbol_dependencies)
+CppClassGenerator::CppClassGenerator(std::string class_name, std::vector<std::string> namespaces, std::vector<Blast::ParentClassProperties> parent_classes_properties, std::vector<ClassAttributeProperties> attribute_properties, std::vector<Blast::SymbolDependencies> symbol_dependencies)
    : class_name(class_name)
    , namespaces(namespaces)
+   , parent_classes_properties(parent_classes_properties)
    , attribute_properties(attribute_properties)
    , symbol_dependencies(symbol_dependencies)
 {
@@ -91,6 +92,12 @@ std::vector<std::string> CppClassGenerator::initialization_list_elements()
 void CppClassGenerator::set_class_name(std::string class_name)
 {
    this->class_name = class_name;
+}
+
+
+bool CppClassGenerator::has_parent_classes()
+{
+   return !parent_classes_properties.empty();
 }
 
 

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -82,11 +82,12 @@ std::vector<std::string> CppClassGenerator::constructor_definition_elements()
 std::vector<std::string> CppClassGenerator::initialization_list_elements()
 {
    std::vector<std::string> elements;
+   for (auto &parent_class_properties : parent_classes_properties)
+      elements.push_back(parent_class_properties.as_argument_in_initialization_list());
    for (auto &attribute_property : attribute_properties)
       elements.push_back(attribute_property.as_argument_in_initialization_list());
    return elements;
 }
-
 
 
 void CppClassGenerator::set_class_name(std::string class_name)

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -90,6 +90,15 @@ std::vector<std::string> CppClassGenerator::initialization_list_elements()
 }
 
 
+std::vector<std::string> CppClassGenerator::class_declaration_opener_inheritence_elements()
+{
+   std::vector<std::string> elements;
+   for (auto &parent_class_properties : parent_classes_properties)
+      elements.push_back(parent_class_properties.as_class_inheritence_declaration());
+   return elements;
+}
+
+
 void CppClassGenerator::set_class_name(std::string class_name)
 {
    this->class_name = class_name;
@@ -169,10 +178,24 @@ std::string CppClassGenerator::namespaces_scope_closer(bool indented, bool inclu
 }
 
 
+std::string CppClassGenerator::class_declaration_inheritence_list()
+{
+   std::stringstream result;
+   if (!has_parent_classes()) return "";
+
+   result << " : ";
+   for (int i=0; i<parent_classes_properties.size()-1; i++)
+      result << parent_classes_properties[i].as_class_inheritence_declaration() << ", ";
+   result << parent_classes_properties.back().as_class_inheritence_declaration();
+
+   return result.str();
+}
+
+
 std::string CppClassGenerator::class_declaration_opener(int indent_level)
 {
    std::stringstream result;
-   result << std::string(3*indent_level, ' ') << "class " << class_name << "\n" << std::string(3*indent_level, ' ') << "{\n";
+   result << std::string(3*indent_level, ' ') << "class " << class_name << class_declaration_inheritence_list() << "\n" << std::string(3*indent_level, ' ') << "{\n";
    return result.str();
 }
 

--- a/src/ParentClassProperties.cpp
+++ b/src/ParentClassProperties.cpp
@@ -78,6 +78,14 @@ std::string ParentClassProperties::get_scope_specifier()
 }
 
 
+std::string ParentClassProperties::as_class_inheritence_declaration()
+{
+   std::stringstream result;
+   result << scope_specifier << ' ' << class_name;
+   return result.str();
+}
+
+
 std::string ParentClassProperties::as_argument_in_initialization_list()
 {
    std::stringstream result;

--- a/src/ParentClassProperties.cpp
+++ b/src/ParentClassProperties.cpp
@@ -78,6 +78,14 @@ std::string ParentClassProperties::get_scope_specifier()
 }
 
 
+std::string ParentClassProperties::as_argument_in_initialization_list()
+{
+   std::stringstream result;
+   result << class_name << '(' << constructor_arguments << ')';
+   return result.str();
+}
+
+
 } // namespace Blast
 
 

--- a/src/ParentClassProperties.cpp
+++ b/src/ParentClassProperties.cpp
@@ -1,0 +1,83 @@
+
+
+#include <Blast/ParentClassProperties.hpp>
+
+#include <sstream>
+
+
+namespace Blast
+{
+
+
+static const std::vector<std::string> SCOPE_SPECIFIERS = { "public", "private", "protected" };
+
+
+ParentClassProperties::ParentClassProperties(std::string class_name, std::string constructor_arguments, std::string scope_specifier)
+   : class_name(class_name)
+   , constructor_arguments(constructor_arguments)
+   , scope_specifier(scope_specifier)
+{
+   __validate_scope_specifier(true);
+}
+
+
+ParentClassProperties::~ParentClassProperties()
+{
+}
+
+
+bool ParentClassProperties::__validate_scope_specifier(bool raise_on_error)
+{
+   bool found = std::find(SCOPE_SPECIFIERS.begin(), SCOPE_SPECIFIERS.end(), scope_specifier) != SCOPE_SPECIFIERS.end();
+   if (raise_on_error && !found)
+   {
+      std::stringstream error_message;
+      error_message << "Invalid scope_specifier, must be one of [";
+      for (auto &value : SCOPE_SPECIFIERS) error_message << "\"" << value << "\", ";
+      error_message << "]";
+      throw std::invalid_argument(error_message.str());
+   }
+   return found;
+}
+
+
+void ParentClassProperties::set_class_name(std::string class_name)
+{
+   this->class_name = class_name;
+}
+
+
+void ParentClassProperties::set_constructor_arguments(std::string constructor_arguments)
+{
+   this->constructor_arguments = constructor_arguments;
+}
+
+
+void ParentClassProperties::set_scope_specifier(std::string scope_specifier)
+{
+   this->scope_specifier = scope_specifier;
+   __validate_scope_specifier(true);
+}
+
+
+std::string ParentClassProperties::get_class_name()
+{
+   return class_name;
+}
+
+
+std::string ParentClassProperties::get_constructor_arguments()
+{
+   return constructor_arguments;
+}
+
+
+std::string ParentClassProperties::get_scope_specifier()
+{
+   return scope_specifier;
+}
+
+
+} // namespace Blast
+
+

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -174,7 +174,7 @@ TEST_F(CppClassGeneratorTest, class_declaration_inheritence_list__returns_a_form
 {
    Blast::CppClassGenerator class_generator("Ascend", {}, { { "Action", "\"ascend_action\"", "private" }, { "Scriptable<Ascend>", "", "protected" } });
 
-   std::string expected_elements = ": private Action, protected Scriptable<Ascend>";
+   std::string expected_elements = " : private Action, protected Scriptable<Ascend>";
    ASSERT_EQ(expected_elements, class_generator.class_declaration_inheritence_list());
 }
 

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -14,7 +14,7 @@ protected:
 
    virtual void SetUp()
    {
-      class_generator_fixture = Blast::CppClassGenerator("User", {}, {
+      class_generator_fixture = Blast::CppClassGenerator("User", {}, {}, {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_constructor_parameter, bool has_getter, bool has_setter
          { "int", "id", "last_id++", false, false, true, false },
          { "std::string", "name", "\"[unnamed]\"", false, true, true, true },
@@ -60,6 +60,23 @@ TEST_F(CppClassGeneratorTest, can_get_and_set_the_class_name)
    ASSERT_EQ("Animal", class_generator.get_class_name());
    class_generator.set_class_name("ClassAttributeProperties");
    ASSERT_EQ("ClassAttributeProperties", class_generator.get_class_name());
+}
+
+
+TEST_F(CppClassGeneratorTest, has_parent_classes__returns_true_if_parent_classes_are_present)
+{
+   Blast::CppClassGenerator class_generator1("CppClassGenerator", {}, { { "Blast" } });
+   ASSERT_TRUE(class_generator1.has_parent_classes());
+
+   Blast::CppClassGenerator class_generator2("Ascend", {}, { { "ActionBase" }, { "Scriptable<Ascend>" } });
+   ASSERT_TRUE(class_generator2.has_parent_classes());
+}
+
+
+TEST_F(CppClassGeneratorTest, has_parent_classes__returns_false_if_parent_classes_are_not_present)
+{
+   Blast::CppClassGenerator class_generator("User");
+   ASSERT_FALSE(class_generator.has_parent_classes());
 }
 
 
@@ -243,7 +260,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_d
       { "Blast::DiceRoller", { "Blast/DiceRoller.hpp" } },
    };
 
-   class_generator_fixture = Blast::CppClassGenerator("User", {}, {
+   class_generator_fixture = Blast::CppClassGenerator("User", {}, {}, {
          { "std::string", "name", "\"[unnamed]\"", false, true, true, true },
          { "Blast::DiceRoller", "dice_roller", "{}", false, true, true, true },
       },
@@ -262,7 +279,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencie
       { "float" },
    };
 
-   class_generator_fixture = Blast::CppClassGenerator("User", {}, {
+   class_generator_fixture = Blast::CppClassGenerator("User", {}, {}, {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_constructor_parameter, bool has_getter, bool has_setter
          { "int", "num_sides", "0", false, false, true, false },
          { "float", "radius", "6.0f", false, true, true, true },
@@ -276,7 +293,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencie
 
 TEST_F(CppClassGeneratorTest, dependency_include_directives__when_a_symbol_dependency_is_not_defined_raises_an_exception)
 {
-   class_generator_fixture = Blast::CppClassGenerator("User", {}, {
+   class_generator_fixture = Blast::CppClassGenerator("User", {}, {}, {
          { "undefined_symbol", "foofoo", "\"foobar\"", false, false, true, false },
       }
    );

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -170,6 +170,15 @@ TEST_F(CppClassGeneratorTest, namespaces_scope_closer__without_namespaces_return
 }
 
 
+TEST_F(CppClassGeneratorTest, class_declaration_inheritence_list__returns_a_formatted_string_listing_the_inherited_classes_for_a_class_opener_statement)
+{
+   Blast::CppClassGenerator class_generator("Ascend", {}, { { "Action", "\"ascend_action\"", "private" }, { "Scriptable<Ascend>", "", "protected" } });
+
+   std::string expected_elements = ": private Action, protected Scriptable<Ascend>";
+   ASSERT_EQ(expected_elements, class_generator.class_declaration_inheritence_list());
+}
+
+
 TEST_F(CppClassGeneratorTest, class_declaration_opener__returns_a_formatted_string_of_the_classes_opener_statement)
 {
    Blast::CppClassGenerator class_generator("Happiness");
@@ -229,6 +238,15 @@ TEST_F(CppClassGeneratorTest, initialization_list_elements__when_properties_are_
 
    std::vector<std::string> expected_elements = { "id(last_id++)", "name(\"[unnamed]\")", "type(MAGE)" };
    ASSERT_EQ(expected_elements, class_generator_fixture.initialization_list_elements());
+}
+
+
+TEST_F(CppClassGeneratorTest, class_declaration_opener_inheritence_elements__returns_a_list_of_formatted_inheritence_elements_for_the_class_declaration_opener)
+{
+   Blast::CppClassGenerator class_generator("Ascend", {}, { { "Action", "\"ascend_action\"", "private" }, { "Scriptable<Ascend>", "", "protected" } });
+
+   std::vector<std::string> expected_elements = { "private Action", "protected Scriptable<Ascend>" };
+   ASSERT_EQ(expected_elements, class_generator.class_declaration_opener_inheritence_elements());
 }
 
 

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -260,7 +260,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_d
       { "Blast::DiceRoller", { "Blast/DiceRoller.hpp" } },
    };
 
-   class_generator_fixture = Blast::CppClassGenerator("User", {}, {}, {
+   Blast::CppClassGenerator class_generator("User", {}, {}, {
          { "std::string", "name", "\"[unnamed]\"", false, true, true, true },
          { "Blast::DiceRoller", "dice_roller", "{}", false, true, true, true },
       },
@@ -268,7 +268,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_d
    );
 
    std::string expected_dependency_directives = "#include <Blast/DiceRoller.hpp>\n#include <string>\n";
-   ASSERT_EQ(expected_dependency_directives, class_generator_fixture.dependency_include_directives());
+   ASSERT_EQ(expected_dependency_directives, class_generator.dependency_include_directives());
 }
 
 
@@ -279,7 +279,7 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencie
       { "float" },
    };
 
-   class_generator_fixture = Blast::CppClassGenerator("User", {}, {}, {
+   Blast::CppClassGenerator class_generator("User", {}, {}, {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_constructor_parameter, bool has_getter, bool has_setter
          { "int", "num_sides", "0", false, false, true, false },
          { "float", "radius", "6.0f", false, true, true, true },
@@ -287,18 +287,18 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencie
       symbol_dependencies
    );
 
-   ASSERT_EQ("", class_generator_fixture.dependency_include_directives());
+   ASSERT_EQ("", class_generator.dependency_include_directives());
 }
 
 
 TEST_F(CppClassGeneratorTest, dependency_include_directives__when_a_symbol_dependency_is_not_defined_raises_an_exception)
 {
-   class_generator_fixture = Blast::CppClassGenerator("User", {}, {}, {
+   Blast::CppClassGenerator class_generator("User", {}, {}, {
          { "undefined_symbol", "foofoo", "\"foobar\"", false, false, true, false },
       }
    );
 
-   ASSERT_THROW(class_generator_fixture.dependency_include_directives(), std::runtime_error);
+   ASSERT_THROW(class_generator.dependency_include_directives(), std::runtime_error);
 }
 
 

--- a/tests/ParentClassPropertiesTest.cpp
+++ b/tests/ParentClassPropertiesTest.cpp
@@ -83,3 +83,11 @@ TEST(ParentClassPropertiesTest, can_get_and_set_constructor_arguments)
 }
 
 
+TEST(ParentClassPropertiesTest, as_argument_in_initialization_list__returns_a_string_formatted_for_an_initialization_list)
+{
+   Blast::ParentClassProperties parent_class_properties("Donkey", "1234, \"tree\", new SurfaceAreaBox(3, 5, 7, 13)", "private");
+   std::string expected_initialization_list_argument = "Donkey(1234, \"tree\", new SurfaceAreaBox(3, 5, 7, 13))";
+   ASSERT_EQ(expected_initialization_list_argument, parent_class_properties.as_argument_in_initialization_list());
+}
+
+

--- a/tests/ParentClassPropertiesTest.cpp
+++ b/tests/ParentClassPropertiesTest.cpp
@@ -83,6 +83,14 @@ TEST(ParentClassPropertiesTest, can_get_and_set_constructor_arguments)
 }
 
 
+TEST(ParentClassPropertiesTest, as_class_inheritence_declaration__returns_a_string_formatted_for_class_inheritence_declaration)
+{
+   Blast::ParentClassProperties parent_class_properties("Donkey", "1234, \"tree\", new SurfaceAreaBox(3, 5, 7, 13)", "private");
+   std::string expected_initialization_list_argument = "private Donkey";
+   ASSERT_EQ(expected_initialization_list_argument, parent_class_properties.as_class_inheritence_declaration());
+}
+
+
 TEST(ParentClassPropertiesTest, as_argument_in_initialization_list__returns_a_string_formatted_for_an_initialization_list)
 {
    Blast::ParentClassProperties parent_class_properties("Donkey", "1234, \"tree\", new SurfaceAreaBox(3, 5, 7, 13)", "private");

--- a/tests/ParentClassPropertiesTest.cpp
+++ b/tests/ParentClassPropertiesTest.cpp
@@ -1,0 +1,85 @@
+
+
+#include <gtest/gtest.h>
+
+#include <Blast/ParentClassProperties.hpp>
+
+#include <cmath>
+
+
+TEST(ParentClassPropertiesTest, can_be_created)
+{
+   Blast::ParentClassProperties parent_class_properties;
+}
+
+
+TEST(ParentClassPropertiesTest, when_created_without_arguments_has_the_expected_values)
+{
+   Blast::ParentClassProperties parent_class_properties;
+
+   ASSERT_EQ("", parent_class_properties.get_class_name());
+   ASSERT_EQ("", parent_class_properties.get_constructor_arguments());
+   ASSERT_EQ("public", parent_class_properties.get_scope_specifier());
+}
+
+
+TEST(ParentClassPropertiesTest, when_created_with_arguments_sets_the_expected_values)
+{
+   Blast::ParentClassProperties parent_class_properties("Donkey", "13", "private");
+
+   ASSERT_EQ("Donkey", parent_class_properties.get_class_name());
+   ASSERT_EQ("13", parent_class_properties.get_constructor_arguments());
+   ASSERT_EQ("private", parent_class_properties.get_scope_specifier());
+}
+
+
+TEST(ParentClassPropertiesTest, can_get_and_set_class_name)
+{
+   Blast::ParentClassProperties parent_class_properties;
+
+   parent_class_properties.set_class_name("Animal");
+   ASSERT_EQ("Animal", parent_class_properties.get_class_name());
+   parent_class_properties.set_class_name("Blast::ParentClassProperties");
+   ASSERT_EQ("Blast::ParentClassProperties", parent_class_properties.get_class_name());
+   parent_class_properties.set_class_name("Hamster");
+   ASSERT_EQ("Hamster", parent_class_properties.get_class_name());
+}
+
+
+TEST(ParentClassPropertiesTest, can_get_and_set_scope_specifier)
+{
+   Blast::ParentClassProperties parent_class_properties;
+
+   parent_class_properties.set_scope_specifier("public");
+   ASSERT_EQ("public", parent_class_properties.get_scope_specifier());
+   parent_class_properties.set_scope_specifier("private");
+   ASSERT_EQ("private", parent_class_properties.get_scope_specifier());
+   parent_class_properties.set_scope_specifier("protected");
+   ASSERT_EQ("protected", parent_class_properties.get_scope_specifier());
+}
+
+
+TEST(ParentClassPropertiesTest, when_constructing_with_an_invalid_scope_specifier_raises_an_exception)
+{
+   ASSERT_THROW(Blast::ParentClassProperties("Donkey", "13", "not a valid property"), std::invalid_argument);
+}
+
+
+TEST(ParentClassPropertiesTest, when_setting_a_scope_specifier_to_an_invalid_value_raises_an_exception)
+{
+   Blast::ParentClassProperties parent_class_properties;
+   ASSERT_THROW(parent_class_properties.set_scope_specifier("not a valid property"), std::invalid_argument);
+}
+
+
+TEST(ParentClassPropertiesTest, can_get_and_set_constructor_arguments)
+{
+   Blast::ParentClassProperties parent_class_properties;
+
+   parent_class_properties.set_constructor_arguments("\"Donkey\"");
+   ASSERT_EQ("\"Donkey\"", parent_class_properties.get_constructor_arguments());
+   parent_class_properties.set_constructor_arguments("1234, \"tree\", new SurfaceAreaBox(3, 5, 7, 13)");
+   ASSERT_EQ("1234, \"tree\", new SurfaceAreaBox(3, 5, 7, 13)", parent_class_properties.get_constructor_arguments());
+}
+
+


### PR DESCRIPTION
## Add Parent Classes

This PR expands the `CppClassGenerator` further by adding the feature of parent classes.  Parent classes are specified with a class name, scoping, and optional args for construction.  By including parent classes in a spec, the generator will provide the following:

1) Parent classes are listed in the generated classes declaration (with appropriate scoping)
1) The parent class initialization will be included in the generated class's constructor
3) Optional arguments allow setting custom arguments for the parent class initialization

## Validations

Note that `ParentClassProperties` will blow up if you try to assign anything but `private`, `public` or `protected` as a scope specifier.  For validation, a simple internal function is used, but the ideal pattern for validations like this could evolve somewhat over time.