### PR TITLE
Include Base Class Headers in Generated Derived Classes 

### DIFF
--- a/examples/CppClassGeneratorExample.cpp
+++ b/examples/CppClassGeneratorExample.cpp
@@ -22,7 +22,8 @@ int main(int argc, char **argv)
       { "AnimalBase", { "Animal/AnimalBase.hpp" } }
    };
 
-   Blast::CppClassGenerator class_generator("Kitten",
+   Blast::CppClassGenerator class_generator(
+      "Kitten",
       { "MyProject" },
       { { "AnimalBase", "\"Kitten\"" } },
       {

--- a/examples/CppClassGeneratorExample.cpp
+++ b/examples/CppClassGeneratorExample.cpp
@@ -17,12 +17,14 @@ int main(int argc, char **argv)
       // some more complex examples
       { "ALLEGRO_BITMAP*", { "allegro5/allegro.h" }, { "~/Repos/username/allegro5/include" }, { "-lallegro" } },
       { "al_get_font_line_height", { "allegro5/allegro.h", "allegro5/allegro_font.h" }, { "~/Repos/username/allegro5/include" }, { "-lallegro_font" } },
-      { "FSEventStreamRef", { "CoreServices/CoreServices.h" }, {}, { "-framework CoreServices" } }
+      { "FSEventStreamRef", { "CoreServices/CoreServices.h" }, {}, { "-framework CoreServices" } },
+      // dependencies for the parent class(es)
+      { "AnimalBase", { "Animal/AnimalBase.hpp" } }
    };
 
    Blast::CppClassGenerator class_generator("Kitten",
       { "MyProject" },
-      { { "Animal", "\"Kitten\"" } },
+      { { "AnimalBase", "\"Kitten\"" } },
       {
          //std::string datatype, std::string variable_name, std::string initialization_value, bool is_static, bool is_constructor_argument, bool has_getter, bool has_setter
          { "int", "id", "last_id++", false, false, true, false },

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -239,13 +239,16 @@ std::string CppClassGenerator::dependency_include_directives()
    std::set<std::string> symbol_dependency_header_directives;
    std::set<std::string> undefined_symbols;
 
+   std::set<std::string> present_symbols;
+   for (auto &attribute_property : attribute_properties) present_symbols.insert(attribute_property.datatype);
+   for (auto &parent_class_properties : parent_classes_properties) present_symbols.insert(parent_class_properties.get_class_name());
 
-   for (auto &attribute_property : attribute_properties)
+   for (auto &present_symbol : present_symbols)
    {
       bool found = false;
       for (auto &individual_symbol_dependencies : symbol_dependencies)
       {
-         if (individual_symbol_dependencies.is_symbol(attribute_property.datatype))
+         if (individual_symbol_dependencies.is_symbol(present_symbol))
          {
             found = true;
             if (individual_symbol_dependencies.requires_header_files())
@@ -257,7 +260,7 @@ std::string CppClassGenerator::dependency_include_directives()
          }
       }
 
-      if (!found) undefined_symbols.insert(attribute_property.datatype);
+      if (!found) undefined_symbols.insert(present_symbol);
    }
 
    if (!undefined_symbols.empty())

--- a/src/CppClassGenerator.cpp
+++ b/src/CppClassGenerator.cpp
@@ -390,7 +390,6 @@ SETTER_FUNCTIONS
 GETTER_FUNCTIONS
 NAMESPACES_CLOSER
 
-
 )END";
 
    std::string result = source_file_template;

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -7,6 +7,12 @@
 #include <cmath>
 
 
+#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, raised_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { EXPECT_EQ(err.what(), std::string( raised_exception_message )); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+
 class CppClassGeneratorTest : public ::testing::Test
 {
 protected:
@@ -290,6 +296,39 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_d
 }
 
 
+TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_directives_for_the_existing_dependencies_for_a_classes_properties)
+{
+   std::vector<Blast::SymbolDependencies> symbol_dependencies = {
+      { "std::string", { "string" } },
+      { "Blast::DiceRoller", { "Blast/DiceRoller.hpp" } },
+   };
+
+   Blast::CppClassGenerator class_generator("User", {}, {}, {
+         { "std::string", "name", "\"[unnamed]\"", false, true, true, true },
+         { "Blast::DiceRoller", "dice_roller", "{}", false, true, true, true },
+      },
+      symbol_dependencies
+   );
+
+   std::string expected_dependency_directives = "#include <Blast/DiceRoller.hpp>\n#include <string>\n";
+   ASSERT_EQ(expected_dependency_directives, class_generator.dependency_include_directives());
+}
+
+
+TEST_F(CppClassGeneratorTest, dependency_include_directives__includes_the_list_of_dependencies_for_parent_classes)
+{
+   std::vector<Blast::SymbolDependencies> symbol_dependencies = {
+      { "ActionBase", { "Fullscore/Action/ActionBase.hpp" } },
+      { "Scriptable<Ascend>", { "Blast/Scriptable.hpp" } },
+   };
+
+   Blast::CppClassGenerator class_generator("Ascend", {}, { { "ActionBase" }, { "Scriptable<Ascend>" } }, {}, symbol_dependencies);
+
+   std::string expected_dependency_directives = "#include <Blast/Scriptable.hpp>\n#include <Fullscore/Action/ActionBase.hpp>\n";
+   ASSERT_EQ(expected_dependency_directives, class_generator.dependency_include_directives());
+}
+
+
 TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencies_are_required_returns_an_empty_string)
 {
    std::vector<Blast::SymbolDependencies> symbol_dependencies = {
@@ -311,12 +350,13 @@ TEST_F(CppClassGeneratorTest, dependency_include_directives__when_no_dependencie
 
 TEST_F(CppClassGeneratorTest, dependency_include_directives__when_a_symbol_dependency_is_not_defined_raises_an_exception)
 {
-   Blast::CppClassGenerator class_generator("User", {}, {}, {
-         { "undefined_symbol", "foofoo", "\"foobar\"", false, false, true, false },
+   Blast::CppClassGenerator class_generator("User", {}, { { "SomeUndefinedParentClass" } }, {
+         { "some_undefined_symbol", "foofoo", "\"foobar\"", false, false, true, false },
       }
    );
 
-   ASSERT_THROW(class_generator.dependency_include_directives(), std::runtime_error);
+   std::string expected_error_message = "Undefined symbol for datatypes [ \"SomeUndefinedParentClass\", \"some_undefined_symbol\",  ]";
+   ASSERT_THROW_WITH_MESSAGE(class_generator.dependency_include_directives(), std::runtime_error, expected_error_message);
 }
 
 

--- a/tests/CppClassGeneratorTest.cpp
+++ b/tests/CppClassGeneratorTest.cpp
@@ -277,25 +277,6 @@ TEST_F(CppClassGeneratorTest, header_include_directive__returns_the_include_line
 }
 
 
-TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_directives_for_the_existing_dependencies)
-{
-   std::vector<Blast::SymbolDependencies> symbol_dependencies = {
-      { "std::string", { "string" } },
-      { "Blast::DiceRoller", { "Blast/DiceRoller.hpp" } },
-   };
-
-   Blast::CppClassGenerator class_generator("User", {}, {}, {
-         { "std::string", "name", "\"[unnamed]\"", false, true, true, true },
-         { "Blast::DiceRoller", "dice_roller", "{}", false, true, true, true },
-      },
-      symbol_dependencies
-   );
-
-   std::string expected_dependency_directives = "#include <Blast/DiceRoller.hpp>\n#include <string>\n";
-   ASSERT_EQ(expected_dependency_directives, class_generator.dependency_include_directives());
-}
-
-
 TEST_F(CppClassGeneratorTest, dependency_include_directives__returns_a_list_of_directives_for_the_existing_dependencies_for_a_classes_properties)
 {
    std::vector<Blast::SymbolDependencies> symbol_dependencies = {


### PR DESCRIPTION
### Now Including Derived Includes

Generated classes have parent classes https://github.com/MarkOates/blast/pull/6, however, their dependent `#include` header files are needed as well.  This PR adds that feature and includes them when they are detected, or raises an exception if a dependency definition is not present.

### New Testing Macro

✨ Also ✨, new to any of my projects, is this convenient testing macro that checks that 1) an error is thrown 2) with the expected message.  The macro looks like this:

```cpp
#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, raised_exception_message) \
  try { code; FAIL() << "Expected " # raised_exception_type; } \
  catch ( raised_exception_type const &err ) { EXPECT_EQ(err.what(), std::string( raised_exception_message )); } \
  catch (...) { FAIL() << "Expected " # raised_exception_type; }
```

Usage might look something like this:

```cpp
ASSERT_THROW_WITH_MESSAGE(Foo.some_func(-9999), std::runtime_error, "Assigned value out of allowed range");
```