### PR TITLE
Add Action::Base and Aciton::Queue

### DIFF
--- a/examples/Action/BaseExample.cpp
+++ b/examples/Action/BaseExample.cpp
@@ -1,0 +1,103 @@
+
+
+#include <Blast/Action/Base.hpp>
+#include <iostream>
+
+
+class ProgramState
+{
+private:
+   bool program_is_aborted;
+   int counter;
+
+public:
+   ProgramState()
+      : program_is_aborted(false)
+      , counter(0)
+   {}
+   void increment_counter()
+   {
+      counter++;
+   }
+   int get_counter()
+   {
+      return counter;
+   }
+   void abort_program()
+   {
+      program_is_aborted = true;
+   }
+   bool is_program_aborted()
+   {
+      return program_is_aborted;
+   }
+};
+
+
+class ProgramAborter : public Blast::Action::Base
+{
+private:
+   ProgramState *program_state;
+
+public:
+   ProgramAborter(ProgramState *program_state)
+      : Blast::Action::Base("ProgramAborter")
+      , program_state(program_state)
+   {}
+   ~ProgramAborter() {}
+
+   bool execute() override
+   {
+      if (!program_state)
+         throw std::invalid_argument("Cannot program_state->abort_program() when program_state is nullptr.");
+
+      std::cout << "Aborting program." << std::endl;
+      program_state->abort_program();
+      return true;
+   }
+};
+
+
+class ProgramCounterIncrementer : public Blast::Action::Base
+{
+private:
+   ProgramState *program_state;
+
+public:
+   ProgramCounterIncrementer(ProgramState *program_state)
+      : Blast::Action::Base("ProgramCounterIncrementer")
+      , program_state(program_state)
+   {}
+   ~ProgramCounterIncrementer() {}
+
+   bool execute() override
+   {
+      if (!program_state)
+         throw std::invalid_argument("Cannot program_state->increment_counter() when program_state is nullptr.");
+
+      std::cout << "Incrementing counter...";
+      program_state->increment_counter();
+      std::cout << " counter is now at " << program_state->get_counter() << std::endl;
+      return true;
+   }
+};
+
+
+int main(int argc, char **argv)
+{
+   ProgramState program_state;
+   Blast::Action::Base *action = nullptr;
+
+   while (!program_state.is_program_aborted())
+   {
+      if (program_state.get_counter() < 10) action = new ProgramCounterIncrementer(&program_state);
+      else action = new ProgramAborter(&program_state);
+
+      action->execute();
+      delete action;
+   }
+
+   return 0;
+}
+
+

--- a/examples/Action/QueueExample.cpp
+++ b/examples/Action/QueueExample.cpp
@@ -1,0 +1,69 @@
+
+
+#include <Blast/Action/Queue.hpp>
+#include <iostream>
+
+
+class ProgramState
+{
+private:
+   int counter;
+
+public:
+   ProgramState()
+      : counter(0)
+   {}
+   ~ProgramState()
+   {}
+
+   void increment_counter()
+   {
+      counter++;
+   }
+   int get_counter()
+   {
+      return counter;
+   }
+};
+
+
+class CounterIncrementer : public Blast::Action::Base
+{
+public:
+   ProgramState *program_state;
+
+   CounterIncrementer(ProgramState *program_state)
+      : Blast::Action::Base("CounterIncrementer")
+      , program_state(program_state)
+   {}
+   ~CounterIncrementer() {}
+
+   bool execute() override
+   {
+      if (!program_state)
+         throw std::runtime_error("Cannot increment counter on a nulptr program_state");
+
+      std::cout << "Incrementing counter...";
+      program_state->increment_counter();
+      std::cout << " counter is now at " << program_state->get_counter() << std::endl;
+      return true;
+   }
+};
+
+
+int main(int argc, char **argv)
+{
+   ProgramState program_state;
+   Blast::Action::Queue queue("Queue(CounterIncrementer)");
+
+   for (int i=0; i<10; i++)
+      queue.add_action(new CounterIncrementer(&program_state));
+
+   std::cout << "Executing Queue..." << std::endl;
+   queue.execute();
+   std::cout << "... Queue execution complete." << std::endl;
+
+   return 0;
+}
+
+

--- a/include/Blast/Action/Base.hpp
+++ b/include/Blast/Action/Base.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+
+#include <string>
+
+
+namespace Blast
+{
+   namespace Action
+   {
+      class Base
+      {
+      private:
+         std::string action_name;
+
+      public:
+         Base(std::string action_name);
+         virtual ~Base();
+
+         std::string get_action_name();
+
+         virtual bool execute() = 0;
+      };
+   }
+}
+
+

--- a/include/Blast/Action/Queue.hpp
+++ b/include/Blast/Action/Queue.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+
+#include <Blast/Action/Base.hpp>
+#include <vector>
+
+
+namespace Blast
+{
+   namespace Action
+   {
+      class Queue : public Base
+      {
+      private:
+         std::vector<Action::Base *> actions;
+
+      public:
+         Queue(std::string name, std::vector<Action::Base *> actions = {});
+         ~Queue();
+
+         bool execute() override;
+
+         std::vector<Action::Base *> get_actions();
+         bool add_action(Action::Base *action);
+         bool clear();
+      };
+   }
+}
+
+

--- a/src/Action/Base.cpp
+++ b/src/Action/Base.cpp
@@ -1,0 +1,29 @@
+
+
+#include <Blast/Action/Base.hpp>
+
+
+namespace Blast
+{
+namespace Action
+{
+
+
+Base::Base(std::string action_name)
+  : action_name(action_name)
+{}
+
+
+Base::~Base() {}
+
+
+std::string Base::get_action_name()
+{
+   return action_name;
+}
+
+
+} // namespace Action
+} // namespace Blast
+
+

--- a/src/Action/Queue.cpp
+++ b/src/Action/Queue.cpp
@@ -1,0 +1,80 @@
+
+
+#include <Blast/Action/Queue.hpp>
+
+#include <sstream>
+
+
+namespace Blast
+{
+namespace Action
+{
+
+
+Queue::Queue(std::string name, std::vector<Base *> actions)
+   : Base(std::string("Queue<" + name + ">"))
+   , actions(actions)
+{
+}
+
+
+Queue::~Queue()
+{
+   clear();
+}
+
+
+bool Queue::execute()
+{
+   bool status = true;
+   for (auto &action : actions)
+   {
+      bool action_execution_status = false;
+      try
+      {
+         action_execution_status = action->execute();
+      }
+      catch (const std::exception &err)
+      {
+         std::stringstream error_message;
+         error_message << get_action_name() << " error: The queued action \"" << action->get_action_name() << "\" raised the following exception: ";
+         error_message << "\"" << err.what() << "\"";
+         throw std::runtime_error(error_message.str());
+      }
+
+      if (!action_execution_status)
+      {
+         std::stringstream error_message;
+         error_message << get_action_name() << " error: The queued action \"" << action->get_action_name() << "\" returned false when executed.";
+         throw std::runtime_error(error_message.str());
+      }
+   }
+   return status;
+}
+
+
+std::vector<Action::Base *> Queue::get_actions()
+{
+   return actions;
+}
+
+
+bool Queue::add_action(Base *action)
+{
+   actions.push_back(action);
+   return true;
+}
+
+
+bool Queue::clear()
+{
+   for (auto &action : actions) delete action;
+   actions.clear();
+   return true;
+}
+
+
+} // namespace Action
+} // namespace Blast
+
+

--- a/tests/Action/BaseTest.cpp
+++ b/tests/Action/BaseTest.cpp
@@ -1,0 +1,44 @@
+
+
+#include <gtest/gtest.h>
+
+#include <Blast/Action/Base.hpp>
+
+
+class DerivedAction : public Blast::Action::Base
+{
+public:
+   int counter;
+
+   DerivedAction()
+      : Blast::Action::Base("DerivedAction")
+      , counter(0)
+   {}
+   ~DerivedAction() {}
+
+   bool execute() override
+   {
+      counter++;
+      return true;
+   }
+};
+
+
+TEST(Action__BaseTest, execute__executes_the_derived_action)
+{
+   DerivedAction derived_action = DerivedAction();
+   Blast::Action::Base *base = &derived_action;
+
+   ASSERT_TRUE(base->execute());
+   ASSERT_EQ(1, derived_action.counter);
+}
+
+
+TEST(Action__BaseTest, get_action_name__returns_the_name_of_the_action)
+{
+   DerivedAction derived_action = DerivedAction();
+
+   ASSERT_EQ("DerivedAction", derived_action.get_action_name());
+}
+
+

--- a/tests/Action/QueueTest.cpp
+++ b/tests/Action/QueueTest.cpp
@@ -1,0 +1,161 @@
+
+
+#include <gtest/gtest.h>
+
+#include <Blast/Action/Queue.hpp>
+
+
+#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, raised_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { EXPECT_EQ(err.what(), std::string( raised_exception_message )); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+
+class TestAction : public Blast::Action::Base
+{
+public:
+   static int num_active;
+
+   bool executed;
+
+   TestAction()
+      : Blast::Action::Base("TestAction")
+      , executed(false)
+   {
+      num_active++;
+   }
+   ~TestAction()
+   {
+      num_active--;
+   }
+
+   bool execute() override
+   {
+      executed = true;
+      return true;
+   }
+};
+
+
+class ReturnsFalseAction : public Blast::Action::Base
+{
+public:
+   ReturnsFalseAction() : Blast::Action::Base("ReturnsFalseAction") {}
+   ~ReturnsFalseAction() {}
+   bool execute() override { return false; }
+};
+
+
+class ThrowsExceptionAction : public Blast::Action::Base
+{
+public:
+   ThrowsExceptionAction() : Blast::Action::Base("ThrowsExceptionAction") {}
+   ~ThrowsExceptionAction() {}
+   bool execute() override { throw std::runtime_error("ThrowsExceptionAction: Exception Thrown"); return false; }
+};
+
+
+int TestAction::num_active = 0;
+
+
+TEST(Action__BaseTest, get_action_name__returns_the_name_of_the_action)
+{
+   Blast::Action::Queue action_queue("MyQueue");
+
+   ASSERT_EQ("Queue<MyQueue>", action_queue.get_action_name());
+}
+
+
+TEST(Action__BaseTest, get_actions__returns_the_actions_in_the_queue)
+{
+   std::vector<Blast::Action::Base *> actions = { new TestAction(), new TestAction(), new TestAction() };
+   Blast::Action::Queue action_queue("MyQueue", actions);
+
+   ASSERT_EQ(actions, action_queue.get_actions());
+}
+
+
+TEST(Action__BaseTest, assigns_actions_when_they_are_passed_as_a_constructor_argument)
+{
+   std::vector<Blast::Action::Base *> actions = { new TestAction(), new TestAction(), new TestAction() };
+   Blast::Action::Queue action_queue("MyQueue", actions);
+
+   ASSERT_EQ(actions, action_queue.get_actions());
+}
+
+
+TEST(Action__BaseTest, add_action__appends_the_action_to_the_queue)
+{
+   std::vector<Blast::Action::Base *> actions = { new TestAction(), new TestAction() };
+   Blast::Action::Queue action_queue("MyQueue", actions);
+   TestAction *action_to_append = new TestAction();
+
+   ASSERT_TRUE(action_queue.add_action(action_to_append));
+
+   std::vector<Blast::Action::Base *> returned_actions = action_queue.get_actions();
+   ASSERT_FALSE(returned_actions.empty());
+   ASSERT_EQ(action_to_append, returned_actions.back());
+}
+
+
+TEST(Action__BaseTest, execute__throws_an_exception_when_an_executed_queued_action_returns_false)
+{
+   Blast::Action::Queue action_queue("MyQueue", { new ReturnsFalseAction() });
+
+   std::string expected_message = "Queue<MyQueue> error: The queued action \"ReturnsFalseAction\" returned false when executed.";
+   ASSERT_THROW_WITH_MESSAGE(action_queue.execute(), std::runtime_error, expected_message);
+}
+
+
+TEST(Action__BaseTest, execute__throws_an_exception_when_an_executed_queued_action_throws_an_exception)
+{
+   Blast::Action::Queue action_queue("MyQueue", { new ThrowsExceptionAction() });
+
+   std::string expected_message = "Queue<MyQueue> error: The queued action \"ThrowsExceptionAction\" raised the following exception: \"ThrowsExceptionAction: Exception Thrown\"";
+   ASSERT_THROW_WITH_MESSAGE(action_queue.execute(), std::runtime_error, expected_message);
+}
+
+
+TEST(Action__BaseTest, execute__executes_all_actions_in_the_queue)
+{
+   std::vector<Blast::Action::Base *> actions = { new TestAction(), new TestAction(), new TestAction() };
+   Blast::Action::Queue action_queue("MyQueue", actions);
+
+   for (auto &action : actions) ASSERT_FALSE(static_cast<TestAction *>(action)->executed);
+
+   ASSERT_TRUE(action_queue.execute());
+
+   for (auto &action : actions) ASSERT_TRUE(static_cast<TestAction *>(action)->executed);
+}
+
+
+TEST(Action__BaseTest, clear__deletes_all_actions_in_the_queue_and_empties_the_queue)
+{
+   ASSERT_EQ(0, TestAction::num_active);
+
+   std::vector<Blast::Action::Base *> actions = { new TestAction(), new TestAction(), new TestAction() };
+
+   ASSERT_EQ(3, TestAction::num_active);
+
+   Blast::Action::Queue action_queue("MyQueue", actions);
+   action_queue.clear();
+
+   ASSERT_EQ(0, TestAction::num_active);
+}
+
+
+TEST(Action__BaseTest, on_destruction_deletes_all_actions_in_the_queue)
+{
+   ASSERT_EQ(0, TestAction::num_active);
+
+   std::vector<Blast::Action::Base *> actions = { new TestAction(), new TestAction(), new TestAction() };
+
+   ASSERT_EQ(3, TestAction::num_active);
+
+   Blast::Action::Queue *action_queue = new Blast::Action::Queue("MyQueue", actions);
+   delete action_queue;
+
+   ASSERT_EQ(0, TestAction::num_active);
+}
+
+


### PR DESCRIPTION
## Actions Are Where It's At

At the heart of the new architecture is an action queue.  This is essentially very similar to a [Command Pattern](https://en.wikipedia.org/wiki/Command_pattern).  FullScore has already [begun to adopt an action pattern](https://github.com/MarkOates/fullscore/blob/master/include/fullscore/action.h), and it's providing an amazingly simplified architecture, where each "step" that is taken in the program can be broken down atomically into a single action, and easily decoupled atomically into a single class.

Piping everything through an action queue makes it:

- easier to manage input devices (keyboard and joystick inputs can both summon the same action)
- easier to manage custom control mapping to different keys
- easier to manage program state when each action is an atomic change
- possible to create undo/redo lists
- possible to write scripts by listing actions in a sequence
- possible to record and/or playback entire project histories
- easier to test single-purpose actions and their effects on dependencies
- easier to manage dependency injection by passing only the necessary dependencies into an action