### PR TITLE
Add CommandLineFlaggedArgumentsParser with tests

### DIFF
--- a/include/Blast/CommandLineFlaggedArgumentsParser.hpp
+++ b/include/Blast/CommandLineFlaggedArgumentsParser.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+
+#include <string>
+#include <vector>
+
+
+namespace Blast
+{
+   class CommandLineFlaggedArgumentsParser
+   {
+   private:
+      std::vector<std::string> command_line_args;
+
+   public:
+      CommandLineFlaggedArgumentsParser(std::vector<std::string> command_line_args);
+      ~CommandLineFlaggedArgumentsParser();
+
+      bool is_flag_present(std::string flag);
+      std::vector<std::vector<std::string>> get_flagged_args(std::string flag);
+
+   private:
+
+      std::vector<int> find_flag_positions(std::string flag);
+      std::vector<std::string> get_args_within_flag(int arg_position);
+      bool is_flag(std::string potential_flag_value);
+   };
+} // namespace Blast
+
+

--- a/src/CommandLineFlaggedArgumentsParser.cpp
+++ b/src/CommandLineFlaggedArgumentsParser.cpp
@@ -1,0 +1,79 @@
+
+
+#include <Blast/CommandLineFlaggedArgumentsParser.hpp>
+
+#include <sstream>
+
+
+namespace Blast
+{
+
+
+CommandLineFlaggedArgumentsParser::CommandLineFlaggedArgumentsParser(std::vector<std::string> command_line_args)
+   : command_line_args(command_line_args)
+{}
+
+
+CommandLineFlaggedArgumentsParser::~CommandLineFlaggedArgumentsParser()
+{}
+
+
+bool CommandLineFlaggedArgumentsParser::is_flag_present(std::string flag)
+{
+   if (!is_flag(flag))
+   {
+      std::stringstream error_message;
+      error_message << "[CommandLineFlaggedArgumentsParser::is_flag_present] error: \"" << flag << "\" is not a valid formatted flag; It must start with '-' character.";
+      throw std::runtime_error(error_message.str());
+   }
+
+   std::vector<std::vector<std::string>> results;
+   for (auto &command_line_arg : command_line_args) { if (command_line_arg == flag) return true; }
+   return false;
+}
+
+
+std::vector<std::vector<std::string>> CommandLineFlaggedArgumentsParser::get_flagged_args(std::string flag)
+{
+   std::vector<std::vector<std::string>> results;
+
+   std::vector<int> positions = find_flag_positions(flag);
+   for (int i=0; i<positions.size(); i++)
+   {
+      results.push_back(get_args_within_flag(positions[i]));
+   }
+   return results;
+}
+
+
+std::vector<int> CommandLineFlaggedArgumentsParser::find_flag_positions(std::string flag)
+{
+   std::vector<int> positions;
+   for (int i=0; i<command_line_args.size(); i++) { if (command_line_args[i] == flag) positions.push_back(i); }
+   return positions;
+}
+
+
+std::vector<std::string> CommandLineFlaggedArgumentsParser::get_args_within_flag(int arg_position)
+{
+   std::vector<std::string> args;
+   for (int i=(arg_position+1); i<command_line_args.size(); i++)
+   {
+      if (is_flag(command_line_args[i])) break;
+      else args.push_back(command_line_args[i]);
+   }
+   return args;
+}
+
+
+bool CommandLineFlaggedArgumentsParser::is_flag(std::string potential_flag_value)
+{
+   if (potential_flag_value.size() < 2) return false;
+   if (potential_flag_value[0] == '-') return true;
+   return false;
+}
+
+
+} // namespace Blast
+
+

--- a/tests/CommandLineFlaggedArgumentsParserTest.cpp
+++ b/tests/CommandLineFlaggedArgumentsParserTest.cpp
@@ -1,0 +1,105 @@
+
+
+#include <gtest/gtest.h>
+
+#include <Blast/CommandLineFlaggedArgumentsParser.hpp>
+
+
+#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, raised_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { EXPECT_EQ(err.what(), std::string( raised_exception_message )); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+
+class CommandLineFlaggedArgumentsParserTest : public ::testing::Test
+{
+protected:
+   static std::vector<std::string> args_fixture;
+
+   virtual void SetUp()
+   {
+      args_fixture = {
+         "-c", "ClassName",
+         "-i", "InterfaceName",
+         "-f", "folder_name",
+         "-n", "ModuleName",
+         "-a", "named_arg_1", "named_arg_2:'default_value'",
+         "-m", "method_name", "method_named_arg:'another_default'",
+         "-m", "another_method_name", "another_method_named_arg:'another_default'",
+      };
+   }
+};
+
+
+std::vector<std::string> CommandLineFlaggedArgumentsParserTest::args_fixture = {};
+
+
+TEST_F(CommandLineFlaggedArgumentsParserTest, can_be_created)
+{
+   Blast::CommandLineFlaggedArgumentsParser parser(args_fixture);
+}
+
+
+TEST_F(CommandLineFlaggedArgumentsParserTest, get_flagged_args__with_a_given_flag_returns_the_expected_passed_arguments)
+{
+   Blast::CommandLineFlaggedArgumentsParser parser(args_fixture);
+
+   std::vector<std::vector<std::string>> expected_results = { { "named_arg_1", "named_arg_2:'default_value'" } };
+   std::vector<std::vector<std::string>> returned_results = parser.get_flagged_args("-a");
+
+   ASSERT_EQ(expected_results, returned_results);
+}
+
+
+TEST_F(CommandLineFlaggedArgumentsParserTest, get_flagged_args__when_multiple_instances_of_a_flag_are_present__returns_the_expected_passed_arguments)
+{
+   Blast::CommandLineFlaggedArgumentsParser parser(args_fixture);
+
+   std::vector<std::vector<std::string>> expected_results = {
+      { "method_name", "method_named_arg:'another_default'" },
+      { "another_method_name", "another_method_named_arg:'another_default'" },
+   };
+   std::vector<std::vector<std::string>> returned_results = parser.get_flagged_args("-m");
+
+   ASSERT_EQ(expected_results, returned_results);
+}
+
+
+TEST_F(CommandLineFlaggedArgumentsParserTest, get_flagged_args__with_a_flag_that_is_not_present_returns_empty_results)
+{
+   Blast::CommandLineFlaggedArgumentsParser parser(args_fixture);
+
+   std::vector<std::vector<std::string>> expected_results = { };
+   std::vector<std::vector<std::string>> returned_results = parser.get_flagged_args("-x");
+
+   ASSERT_EQ(expected_results, returned_results);
+}
+
+
+TEST_F(CommandLineFlaggedArgumentsParserTest, is_flag_present__asdf_asdf_asdf)
+{
+   Blast::CommandLineFlaggedArgumentsParser parser(args_fixture);
+
+   std::string expected_error_message = "[CommandLineFlaggedArgumentsParser::is_flag_present] error: \"not-a-flag\" is not " \
+      "a valid formatted flag; It must start with '-' character.";
+
+   ASSERT_THROW_WITH_MESSAGE(parser.is_flag_present("not-a-flag"), std::runtime_error, expected_error_message)
+}
+
+
+TEST_F(CommandLineFlaggedArgumentsParserTest, is_flag_present__returns_true_if_a_flag_is_present)
+{
+   Blast::CommandLineFlaggedArgumentsParser parser(args_fixture);
+
+   ASSERT_TRUE(parser.is_flag_present("-n"));
+}
+
+
+TEST_F(CommandLineFlaggedArgumentsParserTest, is_flag_present__returns_false_if_a_flag_is_present)
+{
+   Blast::CommandLineFlaggedArgumentsParser parser(args_fixture);
+
+   ASSERT_FALSE(parser.is_flag_present("-x"));
+}
+
+


### PR DESCRIPTION
This class makes it easier to take command line arguments with flags (sometimes called switches), and parse them into usable strings for an application.

A typical command line string with flags might look like this:

```terminal
./my_program_name -c ClassName -a named_arg_1 named_arg_2:'deafult_value' -m method_name method_named_arg:'default_value'
```

Using `CommandLineFlaggedArgumentsParser`, you could pull out the following data:

```cpp
get_flagged_args("-a") // returns { { "named_arg_1", "named_arg_2:'deafult_value'" } }
```