### PR TITLE
Expand Quintessence Features

### DIFF
--- a/documentation/field_definitions.md
+++ b/documentation/field_definitions.md
@@ -47,6 +47,7 @@ Defines the independently-implemented functions on the class.
 | `body` | String | the code body of the function.  No magic happens here, the text you write in this string is simply injected verbatum into the body of the function. |
 
 
+
 ## `functions` > `parameters`
 
 Parameters defining the elements of a function signature:
@@ -56,3 +57,20 @@ Parameters defining the elements of a function signature:
 | `name` | String | variable name of the function parameter |
 | `type` | String | datatype for the function parameter (default is `std::string`) |
 | `default_value` | String | a default argument be assigned to the value if none is present. |
+
+
+
+## `dependencies`
+
+The definitions for each of the dependencies required by this quintessence.
+Dependencies can occour 
+
+| field | type | description |
+| --- | --- | --- |
+| `symbol` | String | The name of the symbol.  Might be something like `std::string` or `int` or `MyCustomClass*` |
+| `headers` | Array of Strings | List of header files and their directories from the root of one of the provided include directories |
+| `include_directories` | Array of Strings | The include directories needed to locate the header file at compile-time. Note that for the standard template library, you won't need to provide include directories. This you can leave empty (e.g. `[]`) |
+| `linked_libraries` | Array of Strings | The names of the libraries as they would be linked to with `-l` at compile-time. Note that for the standard template library, you don't need any linked libraries. This you can leave empty (e.g. `[]`) |
+
+
+

--- a/include/Blast/Cpp/Class.hpp
+++ b/include/Blast/Cpp/Class.hpp
@@ -28,6 +28,7 @@ namespace Blast
          Class(std::string class_name="UnnamedClass", std::vector<std::string> namespaces={}, std::vector<Blast::Cpp::ParentClassProperties> parent_classes_properties={}, std::vector<Blast::Cpp::ClassAttributeProperties> attribute_properties={}, std::vector<Blast::Cpp::Function> functions={}, std::vector<Blast::Cpp::SymbolDependencies> symbol_dependencies={}, std::vector<Blast::Cpp::SymbolDependencies> function_body_symbol_dependencies={});
          ~Class();
 
+         bool infer_has_virtual_functions();
 
          std::string get_class_name();
          std::vector<std::string> get_namespaces();

--- a/include/Blast/Cpp/Function.hpp
+++ b/include/Blast/Cpp/Function.hpp
@@ -20,9 +20,11 @@ namespace Blast
          bool is_static;
          bool is_const;
          bool is_override;
+         bool is_virtual;
+         bool is_pure_virtual;
 
       public:
-         Function(std::string type="void", std::string name="unnamed_function", std::vector<Blast::Cpp::FunctionArgument> signature={}, std::string body="return;", bool is_static=false, bool is_const=false, bool is_override=false);
+         Function(std::string type="void", std::string name="unnamed_function", std::vector<Blast::Cpp::FunctionArgument> signature={}, std::string body="return;", bool is_static=false, bool is_const=false, bool is_override=false, bool is_virtual=false, bool is_pure_virtual=false);
          ~Function();
 
 
@@ -33,6 +35,8 @@ namespace Blast
          bool get_is_static();
          bool get_is_const();
          bool get_is_override();
+         bool get_is_virtual();
+         bool get_is_pure_virtual();
       };
    }
 }

--- a/programs/quintessence_from_yaml.cpp
+++ b/programs/quintessence_from_yaml.cpp
@@ -278,6 +278,8 @@ std::vector<Blast::Cpp::Function> extract_functions(YAML::Node &source)
       const std::string STATIC = "static";
       const std::string CONST = "const";
       const std::string OVERRIDE = "override";
+      const std::string VIRTUAL = "virtual";
+      const std::string PURE_VIRTUAL = "pure_virtual";
 
       validate(it->IsMap(), this_func_name, "Unexpected sequence element in \"functions\", expected to be of a YAML Map.");
 
@@ -288,14 +290,18 @@ std::vector<Blast::Cpp::Function> extract_functions(YAML::Node &source)
       YAML::Node static_node = it->operator[](STATIC);
       YAML::Node const_node = it->operator[](CONST);
       YAML::Node override_node = it->operator[](OVERRIDE);
+      YAML::Node virtual_node = it->operator[](VIRTUAL);
+      YAML::Node pure_virtual_node = it->operator[](PURE_VIRTUAL);
 
       validate(type_node.IsScalar(), this_func_name, "Unexpected type_node, expected to be of YAML type Scalar.");
       validate(name_node.IsScalar(), this_func_name, "Unexpected name_node, expected to be of YAML type Scalar.");
-      validate(parameters_node.IsSequence(), this_func_name, "Unexpected parameters_node, expected to be of YAML type Scalar.");
+      validate(parameters_node.IsSequence(), this_func_name, "Unexpected parameters_node, expected to be of YAML type Sequence.");
       validate(body_node.IsScalar(), this_func_name, "Unexpected body_node, expected to be of YAML type Scalar.");
       validate(static_node.IsScalar(), this_func_name, "Unexpected static_node, expected to be of YAML type Scalar.");
       validate(const_node.IsScalar(), this_func_name, "Unexpected const_node, expected to be of YAML type Scalar.");
       validate(override_node.IsScalar(), this_func_name, "Unexpected override_node, expected to be of YAML type Scalar.");
+      validate(virtual_node.IsScalar(), this_func_name, "Unexpected virtual_node, expected to be of YAML type Scalar.");
+      validate(pure_virtual_node.IsScalar(), this_func_name, "Unexpected pure_virtual_node, expected to be of YAML type Scalar.");
 
       std::string type = type_node.as<std::string>();
       std::string name = name_node.as<std::string>();
@@ -304,8 +310,10 @@ std::vector<Blast::Cpp::Function> extract_functions(YAML::Node &source)
       bool is_static = static_node.as<bool>();
       bool is_const = const_node.as<bool>();
       bool is_override = override_node.as<bool>();
+      bool is_virtual = virtual_node.as<bool>();
+      bool is_pure_virtual = pure_virtual_node.as<bool>();
 
-      Blast::Cpp::Function function(type, name, signature, body, is_static, is_const, is_override);
+      Blast::Cpp::Function function(type, name, signature, body, is_static, is_const, is_override, is_virtual, is_pure_virtual);
 
       result.push_back(function);
    }

--- a/quintessence/Blast/Cpp/Function.q.json
+++ b/quintessence/Blast/Cpp/Function.q.json
@@ -1,7 +1,7 @@
 {
-  "class": "CppFunction",
+  "class": "Function",
   "parent_classes": [],
-  "namespaces": [ "Blast" ],
+  "namespaces": [ "Blast", "Cpp" ],
   "properties" : [
     {
       "name": "type",
@@ -19,7 +19,7 @@
     },
     {
       "name": "signature",
-      "type": "std::vector<Blast::CppFunctionArgument>",
+      "type": "std::vector<Blast::Cpp::FunctionArgument>",
       "init_with": "{}",
       "constructor_arg" : true,
       "getter" : true
@@ -51,33 +51,48 @@
       "init_with": "false",
       "constructor_arg" : true,
       "getter" : true
+    },
+    {
+      "name": "is_virtual",
+      "type": "bool",
+      "init_with": "false",
+      "constructor_arg" : true,
+      "getter" : true
+    },
+    {
+      "name": "is_pure_virtual",
+      "type": "bool",
+      "init_with": "false",
+      "constructor_arg" : true,
+      "getter" : true
     }
   ],
   "functions" : [],
+  "function_body_symbol_dependencies" : [],
   "dependencies" : [
     {
       "symbol" : "std::string",
       "headers" : [ "string" ],
-      "include_directories" : [ "foodir" ],
-      "linked_libraries" : [ "foolib" ]
+      "include_directories" : [],
+      "linked_libraries" : []
     },
     {
       "symbol" : "void",
       "headers" : [],
-      "include_directories" : [ "foodir" ],
-      "linked_libraries" : [ "foolib" ]
+      "include_directories" : [],
+      "linked_libraries" : []
     },
     {
       "symbol" : "bool",
       "headers" : [],
-      "include_directories" : [ "foodir" ],
-      "linked_libraries" : [ "foolib" ]
+      "include_directories" : [],
+      "linked_libraries" : []
     },
     {
-      "symbol" : "std::vector<Blast::CppFunctionArgument>",
-      "headers" : [ "vector", "Blast/CppFunctionArgument.hpp" ],
-      "include_directories" : [ "foodir" ],
-      "linked_libraries" : [ "foolib" ]
+      "symbol" : "std::vector<Blast::Cpp::FunctionArgument>",
+      "headers" : [ "vector", "Blast/Cpp/FunctionArgument.hpp" ],
+      "include_directories" : [],
+      "linked_libraries" : []
     }
   ]
 }

--- a/src/Blast/Cpp/Class.cpp
+++ b/src/Blast/Cpp/Class.cpp
@@ -28,6 +28,13 @@ Class::~Class()
 }
 
 
+bool Class::infer_has_virtual_functions()
+{
+   for (auto &function : get_functions()) if (function.get_is_virtual() || function.get_is_pure_virtual()) return true;
+   return false;
+}
+
+
 std::string Class::get_class_name()
 {
    return class_name;

--- a/src/Blast/Cpp/ClassGenerator.cpp
+++ b/src/Blast/Cpp/ClassGenerator.cpp
@@ -470,7 +470,9 @@ std::string ClassGenerator::constructor_definition(int indent_level)
 std::string ClassGenerator::destructor_declaration(int indent_level)
 {
    std::stringstream result;
-   result << std::string(3*indent_level, ' ') << "~" << cpp_class.get_class_name() << "();\n";
+   result << std::string(3*indent_level, ' ');
+      if (cpp_class.infer_has_virtual_functions()) result << "virtual ";
+      result << "~" << cpp_class.get_class_name() << "();\n";
    return result.str();
 }
 

--- a/src/Blast/Cpp/Function.cpp
+++ b/src/Blast/Cpp/Function.cpp
@@ -3,15 +3,14 @@
 #include <Blast/Cpp/Function.hpp>
 
 
+
 namespace Blast
 {
-
-
 namespace Cpp
 {
 
 
-Function::Function(std::string type, std::string name, std::vector<Blast::Cpp::FunctionArgument> signature, std::string body, bool is_static, bool is_const, bool is_override)
+Function::Function(std::string type, std::string name, std::vector<Blast::Cpp::FunctionArgument> signature, std::string body, bool is_static, bool is_const, bool is_override, bool is_virtual, bool is_pure_virtual)
    : type(type)
    , name(name)
    , signature(signature)
@@ -19,6 +18,8 @@ Function::Function(std::string type, std::string name, std::vector<Blast::Cpp::F
    , is_static(is_static)
    , is_const(is_const)
    , is_override(is_override)
+   , is_virtual(is_virtual)
+   , is_pure_virtual(is_pure_virtual)
 {
 }
 
@@ -70,9 +71,19 @@ bool Function::get_is_override()
 }
 
 
+bool Function::get_is_virtual()
+{
+   return is_virtual;
+}
+
+
+bool Function::get_is_pure_virtual()
+{
+   return is_pure_virtual;
+}
+
+
 } // namespace Cpp
-
-
 } // namespace Blast
 
 

--- a/src/Blast/Cpp/FunctionFormatter.cpp
+++ b/src/Blast/Cpp/FunctionFormatter.cpp
@@ -57,6 +57,8 @@ std::string FunctionFormatter::get_function_definition()
 {
    std::stringstream result;
 
+   if (function.get_is_pure_virtual()) return "";
+
    // format the args
    std::vector<std::string> function_arg_elements;
    for (auto &parameter : function.get_signature())

--- a/src/Blast/Cpp/FunctionFormatter.cpp
+++ b/src/Blast/Cpp/FunctionFormatter.cpp
@@ -40,9 +40,11 @@ std::string FunctionFormatter::get_function_declaration()
 
    // format the function
    if (function.get_is_static()) result << "static ";
+   if (function.get_is_virtual() || function.get_is_pure_virtual()) result << "virtual ";
    result << function.get_type() << " ";
    if (!class_name.empty()) result << class_name << "::";
    result << function.get_name() << "(" << Blast::StringJoiner(function_arg_elements, ", ").join() << ")";
+   if (function.get_is_pure_virtual()) result << " = 0";
    if (function.get_is_const()) result << " const";
    if (function.get_is_override()) result << " override";
    result << ';' << std::endl;

--- a/tests/Blast/Cpp/ClassGeneratorTest.cpp
+++ b/tests/Blast/Cpp/ClassGeneratorTest.cpp
@@ -474,6 +474,20 @@ TEST_F(ClassGeneratorTest, destructor_declaration__returns_the_expected_string)
 }
 
 
+TEST_F(ClassGeneratorTest, destructor_declaration__when_virtual_or_pure_virtual_functions_are_present_on_the_class__returns_the_expected_virtual_destructor_string)
+{
+   Blast::Cpp::Class cpp_class("User", { "ProjectName" }, {}, {}, {
+      Blast::Cpp::Function("void", "unnamed_function",         {}, "return;", false, false, false, false, true),
+      Blast::Cpp::Function("void", "another_unnamed_function", {}, "return;", false, false, false, true, false),
+   });
+
+   Blast::Cpp::ClassGenerator class_generator(cpp_class);
+
+   std::string expected_destructor_declaration = "virtual ~User();\n";
+   ASSERT_EQ(expected_destructor_declaration, class_generator.destructor_declaration());
+}
+
+
 TEST_F(ClassGeneratorTest, destructor_definition_returns_the_expected_string)
 {
    std::string expected_destructor_definition = "User::~User()\n{\n}\n";

--- a/tests/Blast/Cpp/ClassTest.cpp
+++ b/tests/Blast/Cpp/ClassTest.cpp
@@ -1,0 +1,49 @@
+
+
+#include <gtest/gtest.h>
+
+#include <Blast/Cpp/Class.hpp>
+
+#include <cmath>
+
+
+#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, raised_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { EXPECT_EQ(err.what(), std::string( raised_exception_message )); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+
+///////
+
+
+TEST(ClassTest, can_be_created)
+{
+   Blast::Cpp::Class klass;
+}
+
+
+TEST(ClassTest, infer_has_virtual_functions__returns_true_if_virtual_or_pure_virtual_functions_exist_in_the_class)
+{
+   Blast::Cpp::Class cpp_class_with_virtual_function("User", { "ProjectName" }, {}, {}, {
+      Blast::Cpp::Function("void", "unnamed_function",         {}, "return;", false, false, false, true, false),
+      Blast::Cpp::Function("void", "another_unnamed_function", {}, "return;", false, false, false, false, false),
+   });
+
+   Blast::Cpp::Class cpp_class_with_pure_virtual_function("User", { "ProjectName" }, {}, {}, {
+      Blast::Cpp::Function("void", "unnamed_function",         {}, "return;", false, false, false, false, false),
+      Blast::Cpp::Function("void", "another_unnamed_function", {}, "return;", false, false, false, false, true),
+   });
+
+   ASSERT_TRUE(cpp_class_with_virtual_function.infer_has_virtual_functions());
+   ASSERT_TRUE(cpp_class_with_pure_virtual_function.infer_has_virtual_functions());
+}
+
+
+TEST(ClassTest, infer_has_virtual_functions__returns_false_if_virtual_or_pure_virtual_functions_do_not_exist_in_the_class)
+{
+   Blast::Cpp::Class cpp_class("User", { "ProjectName" }, {}, {}, {});
+
+   ASSERT_FALSE(cpp_class.infer_has_virtual_functions());
+}
+
+

--- a/tests/Blast/Cpp/FunctionFormatterTest.cpp
+++ b/tests/Blast/Cpp/FunctionFormatterTest.cpp
@@ -96,3 +96,13 @@ TEST(FunctionFormatterTest, get_function_definition__with_a_class_name_returns_t
 }
 
 
+TEST(FunctionFormatterTest, get_function_definition__with_a_pure_virtual_function_returns_the_expected_empty_string)
+{
+   Blast::Cpp::Function function("void", "my_function_name", {}, "  return \"hello world!\";", false, false, false, false, true);
+   Blast::Cpp::FunctionFormatter function_formatter(function, "MyClassName");
+
+   std::string expected_returned_string = "";
+   ASSERT_EQ(expected_returned_string, function_formatter.get_function_definition());
+}
+
+

--- a/tests/Blast/Cpp/FunctionFormatterTest.cpp
+++ b/tests/Blast/Cpp/FunctionFormatterTest.cpp
@@ -45,6 +45,26 @@ TEST(FunctionFormatterTest, get_function_declaration__with_a_class_name_returns_
 }
 
 
+TEST(FunctionFormatterTest, get_function_declaration__with_a_virtual_function_returns_the_expected_formatted_string)
+{
+   Blast::Cpp::Function function("void", "my_function_name", {}, "  return \"hello world!\";", false, false, false, true, false);
+   Blast::Cpp::FunctionFormatter function_formatter(function, "MyClassName");
+
+   std::string expected_returned_string = "virtual void MyClassName::my_function_name();\n";
+   ASSERT_EQ(expected_returned_string, function_formatter.get_function_declaration());
+}
+
+
+TEST(FunctionFormatterTest, get_function_declaration__with_a_pure_virtual_function_returns_the_expected_formatted_string)
+{
+   Blast::Cpp::Function function("void", "my_function_name", {}, "  return \"hello world!\";", false, false, false, false, true);
+   Blast::Cpp::FunctionFormatter function_formatter(function, "MyClassName");
+
+   std::string expected_returned_string = "virtual void MyClassName::my_function_name() = 0;\n";
+   ASSERT_EQ(expected_returned_string, function_formatter.get_function_declaration());
+}
+
+
 TEST(FunctionFormatterTest, get_function_definition__returns_the_expected_formatted_string)
 {
    Blast::Cpp::Function function("void", "my_function_name", {}, "  return \"hello world!\";", false, false, false);


### PR DESCRIPTION
This PR adds a small smattering of features:

* Allow `Cpp::Function` to have "`virtual`" and "`pure_virtual`" properties.
* Add a `dependencies` section in the `field_definitions` documentation.
* Expand the `quintessence_from_yaml` program to take in `virtual` and `pure_virtual` keys/value
* Fix up the `quintessence/Blast/Cpp/Function.q.json` and use it as source to `Cpp::Function` source code.
* Add `infer_has_virtual_functions()` to `Cpp::Class` for convenience.
* Modify the `destructor_declaration()` in `Cpp::ClassGenerator` to prefix `virtual` in `virtual ~Destructor();` when virtual functions are present along with test.
* Format virtual and pure virtual function definitions and declarations appropriately in `Cpp::ClassGenerator` and add tests.