### PR TITLE
Expand Quintessence with More Stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ run_tests: tests
 obj/%.o: src/%.cpp
 	@mkdir -p $(@D)
 	@printf "compiling object for \e[1m\e[34m$<\033[0m...\n"
-	g++ -c -std=gnu++11 -Wall -Wuninitialized -Weffc++ $< -o $@ -I./include
+	g++ -c -std=gnu++11 -Wall -Wuninitialized -Weffc++ $< -o $@ -I./include -I$(YAML_CPP_INCLUDE_DIR)
 	@echo "done. object at \033[1m\033[32m$@\033[0m"
 
 

--- a/documentation/field_definitions.md
+++ b/documentation/field_definitions.md
@@ -33,6 +33,29 @@ hash
 
 
 
+## `properties`
+
+#### type: Array of Hashes
+
+The properties field represents all attributes that exist on the class.  Two
+imporant things to know.  First, _all fields are not directly accessible in the
+class and are scoped privately within the class_.  If you want to make the properties
+accessible then you will need to set getters and setters for them.  Also, note
+that each type will need to be defined in the dependencies.
+
+| field | type | description |
+| --- | --- | --- |
+| `name` | String | The variable name for the property. |
+| `type` | String | Datatype for the preopty (something like `std::string`, `void`, `int`, `MyCustomType*`, `std::vector<int>`, etc.).  Note that the datatype will need to be defined in `dependencies`. |
+| `init_with` | String | A hard-injected string that is placed as the default value for this property.  If the property is a constructor argument, then the value is assigned as a default argument in the constructor, otherwise the value is assigned in the initialization list. |
+| `constructor_arg` | Boolean | `true` if the property will appear as an argument in the constructor, otherwise `false` |
+| `static` | Boolean | A value of `true` will mark the property as a `static` property.  It's default value will be assigned in the `.cpp` source file. |
+| `getter` | Boolean | A value of `true` will create a `get_*()` function for this property. |
+| `setter` | Boolean | A value of `true` will create a `set_*()` function for this property. |
+
+
+
+
 ## `functions`
 
 #### type: Array of Hashes
@@ -57,29 +80,6 @@ Parameters defining the elements of a function signature:
 | `name` | String | variable name of the function parameter |
 | `type` | String | datatype for the function parameter (default is `std::string`) |
 | `default_argument` | String | a default argument be assigned to the value if none is present. |
-
-
-
-
-## `properties`
-
-#### type: Array of Hashes
-
-The properties field represents all attributes that exist on the class.  Two
-imporant things to know.  First, _all fields are not directly accessible in the
-class and are scoped privately within the class_.  If you want to make the properties
-accessible then you will need to set getters and setters for them.  Also, note
-that each type will need to be defined in the dependencies.
-
-| field | type | description |
-| --- | --- | --- |
-| `name` | String | The variable name for the property. |
-| `type` | String | Datatype for the preopty (something like `std::string`, `void`, `int`, `MyCustomType*`, `std::vector<int>`, etc.).  Note that the datatype will need to be defined in `dependencies`. |
-| `init_with` | String | A hard-injected string that is placed as the default value for this property.  If the property is a constructor argument, then the value is assigned as a default argument in the constructor, otherwise the value is assigned in the initialization list. |
-| `constructor_arg` | Boolean | `true` if the property will appear as an argument in the constructor, otherwise `false` |
-| `static` | Boolean | A value of `true` will mark the property as a `static` property.  It's default value will be assigned in the `.cpp` source file. |
-| `getter` | Boolean | A value of `true` will create a `get_*()` function for this property. |
-| `setter` | Boolean | A value of `true` will create a `set_*()` function for this property. |
 
 
 

--- a/documentation/field_definitions.md
+++ b/documentation/field_definitions.md
@@ -3,6 +3,7 @@
 ## `class`
 
 #### type: String
+#### default: (YAML: A default value will be inferred from the basename of the filename)
 
 Provide the base name of your class, without namespaces.  This should be in
 camel case and should match the basename of the quintessence file.
@@ -12,6 +13,7 @@ camel case and should match the basename of the quintessence file.
 ## `format`
 
 #### type: String
+#### default: none (YAML: this key/value is not used)
 
 For now, the value should always be "`verbose`".  This means that all fields should be present and
 there are no defaults for missing values.
@@ -21,6 +23,7 @@ there are no defaults for missing values.
 ## `parent_classes`
 
 #### type: Array of Hashes
+#### default: `[]`
 
 Defines the parent classes that this class inherits from.  Each parent class
 hash
@@ -36,6 +39,7 @@ hash
 ## `properties`
 
 #### type: Array of Hashes
+#### default: `[]`
 
 The properties field represents all attributes that exist on the class.  Two
 imporant things to know.  First, _all fields are not directly accessible in the
@@ -59,6 +63,7 @@ that each type will need to be defined in the dependencies.
 ## `functions`
 
 #### type: Array of Hashes
+#### default: `[]`
 
 Defines the independently-implemented functions on the class.
 
@@ -83,10 +88,19 @@ Parameters defining the elements of a function signature:
 
 
 
+## `function_body_symbol_dependencies`
+
+#### type: Array of Strings
+#### default: `[]`
+
+A list of symbol names used in the `body` of all the defined `function`s.  The symbol names listed will need to be included in the `dependencies` list (unless the `dependencies` have default definitions in that list.)
+
+
 
 ## `dependencies`
 
 #### type: Array of Hashes
+#### default: `[]`
 
 The definitions for each of the dependencies required by this quintessence.
 Dependencies can occour 

--- a/documentation/field_definitions.md
+++ b/documentation/field_definitions.md
@@ -89,7 +89,7 @@ Parameters defining the elements of a function signature:
 | field | type | default | description |
 | --- | --- | --- | --- |
 | `name` | String | required | variable name of the function parameter |
-| `type` | String | required | datatype for the function parameter (default is `std::string`) |
+| `type` | String | required | datatype for the function parameter |
 | `default_argument` | String | required | a default argument be assigned to the value if none is present. |
 
 

--- a/documentation/field_definitions.md
+++ b/documentation/field_definitions.md
@@ -56,7 +56,7 @@ Parameters defining the elements of a function signature:
 | --- | --- | --- |
 | `name` | String | variable name of the function parameter |
 | `type` | String | datatype for the function parameter (default is `std::string`) |
-| `default_value` | String | a default argument be assigned to the value if none is present. |
+| `default_argument` | String | a default argument be assigned to the value if none is present. |
 
 
 

--- a/documentation/field_definitions.md
+++ b/documentation/field_definitions.md
@@ -60,7 +60,33 @@ Parameters defining the elements of a function signature:
 
 
 
+
+## `properties`
+
+#### type: Array of Hashes
+
+The properties field represents all attributes that exist on the class.  Two
+imporant things to know.  First, _all fields are not directly accessible in the
+class and are scoped privately within the class_.  If you want to make the properties
+accessible then you will need to set getters and setters for them.  Also, note
+that each type will need to be defined in the dependencies.
+
+| field | type | description |
+| --- | --- | --- |
+| `name` | String | The variable name for the property. |
+| `type` | String | Datatype for the preopty (something like `std::string`, `void`, `int`, `MyCustomType*`, `std::vector<int>`, etc.).  Note that the datatype will need to be defined in `dependencies`. |
+| `init_with` | String | A hard-injected string that is placed as the default value for this property.  If the property is a constructor argument, then the value is assigned as a default argument in the constructor, otherwise the value is assigned in the initialization list. |
+| `constructor_arg` | Boolean | `true` if the property will appear as an argument in the constructor, otherwise `false` |
+| `static` | Boolean | A value of `true` will mark the property as a `static` property.  It's default value will be assigned in the `.cpp` source file. |
+| `getter` | Boolean | A value of `true` will create a `get_*()` function for this property. |
+| `setter` | Boolean | A value of `true` will create a `set_*()` function for this property. |
+
+
+
+
 ## `dependencies`
+
+#### type: Array of Hashes
 
 The definitions for each of the dependencies required by this quintessence.
 Dependencies can occour 

--- a/documentation/field_definitions.md
+++ b/documentation/field_definitions.md
@@ -28,11 +28,11 @@ there are no defaults for missing values.
 Defines the parent classes that this class inherits from.  Each parent class
 hash
 
-| field | type | description |
-| --- | --- | --- |
-| `class` | String | The name of the parent class. |
-| `scope` | String | one of `public`, `private` or `protected`.  Defines the access scope of the inherited class. |
-| `init_with` | String | The string to be injected into the constructor of the parent class, when initialized in the main class's initialization list.  This value you provide is _hard coded_ and is non-magical.  It is simply injected between the `()` of the parent class's construction. |
+| field | type | default | description |
+| --- | --- | --- | --- |
+| `class` | String | required | The name of the parent class. |
+| `scope` | String | required | ne of `public`, `private` or `protected`.  Defines the access scope of the inherited class. |
+| `init_with` | String | required |The string to be injected into the constructor of the parent class, when initialized in the main class's initialization list.  This value you provide is _hard coded_ and is non-magical.  It is simply injected between the `()` of the parent class's construction. |
 
 
 
@@ -47,15 +47,16 @@ class and are scoped privately within the class_.  If you want to make the prope
 accessible then you will need to set getters and setters for them.  Also, note
 that each type will need to be defined in the dependencies.
 
-| field | type | description |
-| --- | --- | --- |
-| `name` | String | The variable name for the property. |
-| `type` | String | Datatype for the preopty (something like `std::string`, `void`, `int`, `MyCustomType*`, `std::vector<int>`, etc.).  Note that the datatype will need to be defined in `dependencies`. |
-| `init_with` | String | A hard-injected string that is placed as the default value for this property.  If the property is a constructor argument, then the value is assigned as a default argument in the constructor, otherwise the value is assigned in the initialization list. |
-| `constructor_arg` | Boolean | `true` if the property will appear as an argument in the constructor, otherwise `false` |
-| `static` | Boolean | A value of `true` will mark the property as a `static` property.  It's default value will be assigned in the `.cpp` source file. |
-| `getter` | Boolean | A value of `true` will create a `get_*()` function for this property. |
-| `setter` | Boolean | A value of `true` will create a `set_*()` function for this property. |
+| field | type | default | description |
+| --- | --- | --- | --- |
+| `name` | String | required | The variable name for the property. |
+| `type` | String | `std::string` | Datatype for the preopty (something like `std::string`, `void`, `int`, `MyCustomType*`, `std::vector<int>`, etc.).  Note that the datatype will need to be defined in `dependencies`. |
+| `init_with` | String | `""` | A hard-injected string that is placed as the default value for this property.  If the property is a constructor argument, then the value is assigned as a default argument in the constructor, otherwise the value is assigned in the initialization list. |
+| `constructor_arg` | Boolean | `false` | `true` if the property will appear as an argument in the constructor, otherwise `false` |
+| `static` | Boolean | `false` | A value of `true` will mark the property as a `static` property.  It's default value will be assigned in the `.cpp` source file. |
+| `getter` | Boolean | `false` | A value of `true` will create a `get_*()` function for this property. |
+| `getter_ref` | Boolean | `false` | A value of `true` will create a `get_*_ref()` function that returns a non-const reference to the value. |
+| `setter` | Boolean | `false` | A value of `true` will create a `set_*()` function for this property. |
 
 
 
@@ -67,12 +68,17 @@ that each type will need to be defined in the dependencies.
 
 Defines the independently-implemented functions on the class.
 
-| field | type | description |
-| --- | --- | --- |
-| `name` | String | The name of the function. |
-| `type` | String | the type of the function, (e.g. `std::string`, `void`, `int`, `MyCustomType`, `std::vector<int>`).  Any type declared must be included in the quintessence's `dependencies` field. |
-| `parameters` | Array of Hashes | Array containing definitions for each parameter in the function signature.  See below for more detail. |
-| `body` | String | the code body of the function.  No magic happens here, the text you write in this string is simply injected verbatum into the body of the function. |
+| field | type | default | description |
+| --- | --- | --- | --- |
+| `name` | String | required | The name of the function. |
+| `type` | String | required | the type of the function, (e.g. `std::string`, `void`, `int`, `MyCustomType`, `std::vector<int>`).  Any type declared must be included in the quintessence's `dependencies` field. |
+| `parameters` | Array of Hashes default | `[]` | Array containing definitions for each parameter in the function signature.  See below for more detail. |
+| `body` | String | required | the code body of the function.  No magic happens here, the text you write in this string is simply injected verbatum into the body of the function. |
+| `is_static` | Bool | `false` | If `true`, defines the function as a `static`. |
+| `is_const` | Bool | `false` | If `true`, defines the function as a `const`. |
+| `is_override` | Bool | `false` | If `true`, defines the function as `override`. |
+| `is_virtal` | Bool | `false` | If `true`, defines function as a `static`. |
+| `is_pure_virtual` | Bool | `false` | If `true`, defines the function as `static`. |
 
 
 
@@ -80,11 +86,11 @@ Defines the independently-implemented functions on the class.
 
 Parameters defining the elements of a function signature:
 
-| field | type | description |
-| --- | --- | --- |
-| `name` | String | variable name of the function parameter |
-| `type` | String | datatype for the function parameter (default is `std::string`) |
-| `default_argument` | String | a default argument be assigned to the value if none is present. |
+| field | type | default | description |
+| --- | --- | --- | --- |
+| `name` | String | required | variable name of the function parameter |
+| `type` | String | required | datatype for the function parameter (default is `std::string`) |
+| `default_argument` | String | required | a default argument be assigned to the value if none is present. |
 
 
 
@@ -105,12 +111,12 @@ A list of symbol names used in the `body` of all the defined `function`s.  The s
 The definitions for each of the dependencies required by this quintessence.
 Dependencies can occour 
 
-| field | type | description |
-| --- | --- | --- |
-| `symbol` | String | The name of the symbol.  Might be something like `std::string` or `int` or `MyCustomClass*` |
-| `headers` | Array of Strings | List of header files and their directories from the root of one of the provided include directories |
-| `include_directories` | Array of Strings | The include directories needed to locate the header file at compile-time. Note that for the standard template library, you won't need to provide include directories. This you can leave empty (e.g. `[]`) |
-| `linked_libraries` | Array of Strings | The names of the libraries as they would be linked to with `-l` at compile-time. Note that for the standard template library, you don't need any linked libraries. This you can leave empty (e.g. `[]`) |
+| field | type | default | description |
+| --- | --- | --- | --- |
+| `symbol` | String | required | The name of the symbol.  Might be something like `std::string` or `int` or `MyCustomClass*` |
+| `headers` | Array of Strings | `[]` | List of header files and their directories from the root of one of the provided include directories |
+| `include_directories` | Array of Strings | `[]` | The include directories needed to locate the header file at compile-time. Note that for the standard template library, you won't need to provide include directories. This you can leave empty (e.g. `[]`) |
+| `linked_libraries` | Array of Strings | `[]` | The names of the libraries as they would be linked to with `-l` at compile-time. Note that for the standard template library, you don't need any linked libraries. This you can leave empty (e.g. `[]`) |
 
 
 

--- a/documentation/quintessence.md
+++ b/documentation/quintessence.md
@@ -4,7 +4,9 @@ Quintessence extrapolation is a technique to automatically generate code based o
 
 Quintessence files have the `.q` extension and contain the meta-definition notated as a JSON structure (JSON definition files contain the full `.q.json` extension. New formats apart from JSON could be added added in the future).
 
-## Generating
+**Note: This document outlines the JSON version of the quintessence extrapolation process.  Please now prefer usage of the YAML process, as it includes a much less verbose set of requirements and sensible defaults.**
+
+## Generating (JSON)
 
 To generate classes from a quintessence file, use the `quintessence_from_json`
 program located in the Blast repository's `programs/` folder.  Once you have

--- a/include/Blast/DirectoryCreator.hpp
+++ b/include/Blast/DirectoryCreator.hpp
@@ -2,6 +2,7 @@
 
 
 #include <string>
+#include <vector>
 
 
 namespace Blast
@@ -9,10 +10,10 @@ namespace Blast
    class DirectoryCreator
    {
    private:
-      std::string directory_name;
+      std::vector<std::string> directory_names;
 
    public:
-      DirectoryCreator(std::string directory_name="");
+      DirectoryCreator(std::vector<std::string> directory_names={});
       ~DirectoryCreator();
 
 

--- a/include/Blast/DirectoryCreator.hpp
+++ b/include/Blast/DirectoryCreator.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+
+#include <string>
+
+
+namespace Blast
+{
+   class DirectoryCreator
+   {
+   private:
+      std::string directory_name;
+
+   public:
+      DirectoryCreator(std::string directory_name="");
+      ~DirectoryCreator();
+
+
+   bool create();
+   };
+}
+
+
+

--- a/include/Blast/DirectoryExistenceChecker.hpp
+++ b/include/Blast/DirectoryExistenceChecker.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+
+#include <string>
+
+
+namespace Blast
+{
+   class DirectoryExistenceChecker
+   {
+   private:
+      std::string directory_name;
+
+   public:
+      DirectoryExistenceChecker(std::string directory_name="");
+      ~DirectoryExistenceChecker();
+
+
+   bool exists();
+   };
+}
+
+
+

--- a/programs/quintessence_from_yaml.cpp
+++ b/programs/quintessence_from_yaml.cpp
@@ -168,6 +168,38 @@ std::vector<Blast::Cpp::ParentClassProperties> extract_parent_classes_properties
 
 
 
+std::string get_type_string(YAML::Node &node)
+{
+   switch (node.Type())
+   {
+   case YAML::NodeType::Null: return "Null"; break;
+   case YAML::NodeType::Scalar: return "Scalar"; break;
+   case YAML::NodeType::Sequence: return "Sequence"; break;
+   case YAML::NodeType::Map: return "Map"; break;
+   case YAML::NodeType::Undefined: return "Undefined"; break;
+   }
+   return "[NO_TYPE_DEFINED_ERROR]";
+}
+
+
+
+bool fetch_bool(YAML::Node &node, std::string key, bool default_value)
+{
+   if (node[key])
+   {
+      if (node[key].IsScalar()) return node.as<bool>();
+      else
+      {
+         std::stringstream error_message;
+         error_message << "unexpected type expecting YAML::IsScalar() " << get_type_string(node) << " is present.";
+         throw std::runtime_error(error_message.str());
+      }
+   }
+   return default_value;
+}
+
+
+
 std::vector<Blast::Cpp::ClassAttributeProperties> extract_attribute_properties(YAML::Node &source)
 {
    std::string this_func_name = "extract_attribute_properties";

--- a/programs/quintessence_from_yaml.cpp
+++ b/programs/quintessence_from_yaml.cpp
@@ -125,6 +125,25 @@ void write_to_files(Blast::Cpp::ClassGenerator &cpp_class_generator, bool automa
 
 
 
+YAML::Node default_dependencies()
+{
+   std::string default_deps = R"END(
+- symbol: int
+- symbol: void
+- symbol: float
+- symbol: double
+- symbol: bool
+- symbol: std::string
+  headers: [ 'string' ]
+- symbol: std::vector<std::string>
+  headers: [ 'vector', 'string' ]
+   )END";
+
+   return YAML::Load(default_deps);
+}
+
+
+
 bool fetch_bool(YAML::Node &node, std::string key, bool default_value)
 {
    if (node[key])
@@ -242,7 +261,7 @@ std::vector<Blast::Cpp::ClassAttributeProperties> extract_attribute_properties(Y
    const std::string PROPERTIES = "properties";
    std::vector<Blast::Cpp::ClassAttributeProperties> result;
 
-   YAML::Node source_attribute_properties = source[PROPERTIES];
+   YAML::Node source_attribute_properties = fetch_node(source, PROPERTIES, YAML::NodeType::Sequence, YAML::Load("[]"));
 
    validate(source_attribute_properties.IsSequence(), this_func_name, "Expected \"properties\" to be of a YAML Sequence type.");
 
@@ -397,7 +416,14 @@ std::vector<Blast::Cpp::SymbolDependencies> extract_symbol_dependencies(YAML::No
    const std::string DEPENDENCIES = "dependencies";
    std::vector<Blast::Cpp::SymbolDependencies> result;
 
-   YAML::Node source_symbol_dependencies = source[DEPENDENCIES];
+   YAML::Node source_symbol_dependencies = fetch_node(source, DEPENDENCIES, YAML::NodeType::Sequence, YAML::Load("[]"));
+   YAML::Node default_deps = default_dependencies();
+
+   // postfix default deps
+   for (std::size_t i=0;i<default_deps.size();i++)
+   {
+      source_symbol_dependencies.push_back(default_deps[i]);
+   }
 
    validate(source_symbol_dependencies.IsSequence(), this_func_name, "Expected \"dependencies\" to be of a YAML Sequence type.");
 

--- a/programs/quintessence_from_yaml.cpp
+++ b/programs/quintessence_from_yaml.cpp
@@ -330,17 +330,20 @@ std::vector<Blast::Cpp::FunctionArgument> convert_function_arguments(YAML::Node 
 
    validate(source.IsSequence(), this_func_name, "Expected \"parameters\" to be of a YAML Sequence type.");
 
-   for (YAML::const_iterator it=source.begin(); it!=source.end(); ++it)
+   for (std::size_t i=0;i<source.size();i++)
+   //for (YAML::const_iterator it=source.begin(); it!=source.end(); ++it)
    {
+      YAML::Node node = source[i];
+
       const std::string TYPE = "type";
       const std::string NAME = "name";
       const std::string DEFAULT_ARGUMENT = "default_argument";
 
-      validate(it->IsMap(), this_func_name, "Unexpected sequence element in \"parameters\", expected to be of a YAML Map.");
+      validate(node.IsMap(), this_func_name, "Unexpected sequence element in \"parameters\", expected to be of a YAML Map.");
 
-      YAML::Node type_node = it->operator[](TYPE);
-      YAML::Node name_node = it->operator[](NAME);
-      YAML::Node default_argument_node = it->operator[](DEFAULT_ARGUMENT);
+      YAML::Node type_node = node.operator[](TYPE);
+      YAML::Node name_node = node.operator[](NAME);
+      YAML::Node default_argument_node = node.operator[](DEFAULT_ARGUMENT);
 
       validate(type_node.IsScalar(), this_func_name, "Unexpected type_node, expected to be of YAML type Scalar.");
       validate(name_node.IsScalar(), this_func_name, "Unexpected name_node, expected to be of YAML type Scalar.");
@@ -382,12 +385,12 @@ std::vector<Blast::Cpp::Function> extract_functions(YAML::Node &source)
 
       YAML::Node type_node = it.operator[](TYPE);
       YAML::Node name_node = it.operator[](NAME);
-      YAML::Node parameters_node = it.operator[](PARAMETERS);
+      YAML::Node parameters_node = fetch_node(it, PARAMETERS, YAML::NodeType::Sequence, YAML::Load("[]"));
       YAML::Node body_node = it.operator[](BODY);
 
       validate(type_node.IsScalar(), this_func_name, "Unexpected type_node, expected to be of YAML type Scalar.");
       validate(name_node.IsScalar(), this_func_name, "Unexpected name_node, expected to be of YAML type Scalar.");
-      validate(parameters_node.IsSequence(), this_func_name, "Unexpected parameters_node, expected to be of YAML type Sequence.");
+      //validate(parameters_node.IsSequence(), this_func_name, "Unexpected parameters_node, expected to be of YAML type Sequence.");
       validate(body_node.IsScalar(), this_func_name, "Unexpected body_node, expected to be of YAML type Scalar.");
 
       std::string type = type_node.as<std::string>();

--- a/quintessence/Blast/DirectoryCreator.q.yml
+++ b/quintessence/Blast/DirectoryCreator.q.yml
@@ -1,0 +1,37 @@
+namespaces: [ 'Blast' ]
+parent_classes: []
+properties:
+  - name: directory_name
+    type: std::string
+    init_with: '""'
+    constructor_arg: true
+functions:
+  - name: create
+    type: bool
+    parameters: []
+    body: |
+      if (Blast::DirectoryExistenceChecker(directory_name).exists()) return true;
+      int mkdir_result = mkdir(directory_name.c_str(), 0777);
+      return mkdir_result != -1;
+function_body_symbol_dependencies: [ 'mkdir', 'std::stringstream', 'Blast::DirectoryExistenceChecker' ]
+dependencies:
+  - symbol: bool
+    headers: []
+    include_directories: []
+    linked_libraries: []
+  - symbol: std::string
+    headers: [ 'string' ]
+    include_directories: []
+    linked_libraries: []
+  - symbol: mkdir
+    headers: [ 'sys/stat.h' ]
+    include_directories: []
+    linked_libraries: []
+  - symbol: std::stringstream
+    headers: [ 'sstream' ]
+    include_directories: []
+    linked_libraries: []
+  - symbol: Blast::DirectoryExistenceChecker
+    headers: [ 'Blast/DirectoryExistenceChecker.hpp' ]
+    include_directories: []
+    linked_libraries: []

--- a/quintessence/Blast/DirectoryCreator.q.yml
+++ b/quintessence/Blast/DirectoryCreator.q.yml
@@ -1,19 +1,28 @@
 namespaces: [ 'Blast' ]
 parent_classes: []
 properties:
-  - name: directory_name
-    type: std::string
-    init_with: '""'
+  - name: directory_names
+    type: std::vector<std::string>
+    init_with: '{}'
     constructor_arg: true
 functions:
   - name: create
     type: bool
     parameters: []
     body: |
-      if (Blast::DirectoryExistenceChecker(directory_name).exists()) return true;
-      int mkdir_result = mkdir(directory_name.c_str(), 0777);
-      return mkdir_result != -1;
-function_body_symbol_dependencies: [ 'mkdir', 'std::stringstream', 'Blast::DirectoryExistenceChecker' ]
+      std::stringstream result_directories;
+      const std::string SEPARATOR = "/";
+      for (auto &directory_name : directory_names)
+      {
+        result_directories << directory_name << SEPARATOR;
+        std::string directory_to_create = result_directories.str();
+
+        if (Blast::DirectoryExistenceChecker(directory_to_create).exists()) continue;
+        int mkdir_result = mkdir(directory_to_create.c_str(), 0777);
+        if (mkdir_result == -1) return false;
+      }
+      return true;
+function_body_symbol_dependencies: [ 'mkdir', 'std::stringstream', 'std::string', 'Blast::DirectoryExistenceChecker' ]
 dependencies:
   - symbol: bool
     headers: []
@@ -21,6 +30,10 @@ dependencies:
     linked_libraries: []
   - symbol: std::string
     headers: [ 'string' ]
+    include_directories: []
+    linked_libraries: []
+  - symbol: std::vector<std::string>
+    headers: [ 'vector', 'string' ]
     include_directories: []
     linked_libraries: []
   - symbol: mkdir

--- a/quintessence/Blast/DirectoryExistenceChecker.q.yml
+++ b/quintessence/Blast/DirectoryExistenceChecker.q.yml
@@ -1,0 +1,28 @@
+namespaces: [ 'Blast' ]
+parent_classes: []
+properties:
+  - name: directory_name
+    type: std::string
+    init_with: '""'
+    constructor_arg: true
+functions:
+  - name: exists
+    type: bool
+    parameters: []
+    body: |
+      struct stat info;
+      return stat(directory_name.c_str(), &info) == 0 && S_ISDIR(info.st_mode);
+function_body_symbol_dependencies: [ 'stat' ]
+dependencies:
+  - symbol: stat
+    headers: [ 'sys/stat.h' ]
+    include_directories: []
+    linked_libraries: []
+  - symbol: bool
+    headers: []
+    include_directories: []
+    linked_libraries: []
+  - symbol: std::string
+    headers: [ 'string' ]
+    include_directories: []
+    linked_libraries: []

--- a/src/Blast/DirectoryCreator.cpp
+++ b/src/Blast/DirectoryCreator.cpp
@@ -3,6 +3,7 @@
 #include <Blast/DirectoryCreator.hpp>
 #include <sys/stat.h>
 #include <sstream>
+#include <string>
 #include <Blast/DirectoryExistenceChecker.hpp>
 
 
@@ -10,8 +11,8 @@ namespace Blast
 {
 
 
-DirectoryCreator::DirectoryCreator(std::string directory_name)
-   : directory_name(directory_name)
+DirectoryCreator::DirectoryCreator(std::vector<std::string> directory_names)
+   : directory_names(directory_names)
 {
 }
 
@@ -23,9 +24,18 @@ DirectoryCreator::~DirectoryCreator()
 
 bool DirectoryCreator::create()
 {
-if (Blast::DirectoryExistenceChecker(directory_name).exists()) return true;
-int mkdir_result = mkdir(directory_name.c_str(), 0777);
-return mkdir_result != -1;
+std::stringstream result_directories;
+const std::string SEPARATOR = "/";
+for (auto &directory_name : directory_names)
+{
+  result_directories << directory_name << SEPARATOR;
+  std::string directory_to_create = result_directories.str();
+
+  if (Blast::DirectoryExistenceChecker(directory_to_create).exists()) continue;
+  int mkdir_result = mkdir(directory_to_create.c_str(), 0777);
+  if (mkdir_result == -1) return false;
+}
+return true;
 
 }
 } // namespace Blast

--- a/src/Blast/DirectoryCreator.cpp
+++ b/src/Blast/DirectoryCreator.cpp
@@ -1,0 +1,33 @@
+
+
+#include <Blast/DirectoryCreator.hpp>
+#include <sys/stat.h>
+#include <sstream>
+#include <Blast/DirectoryExistenceChecker.hpp>
+
+
+namespace Blast
+{
+
+
+DirectoryCreator::DirectoryCreator(std::string directory_name)
+   : directory_name(directory_name)
+{
+}
+
+
+DirectoryCreator::~DirectoryCreator()
+{
+}
+
+
+bool DirectoryCreator::create()
+{
+if (Blast::DirectoryExistenceChecker(directory_name).exists()) return true;
+int mkdir_result = mkdir(directory_name.c_str(), 0777);
+return mkdir_result != -1;
+
+}
+} // namespace Blast
+
+

--- a/src/Blast/DirectoryExistenceChecker.cpp
+++ b/src/Blast/DirectoryExistenceChecker.cpp
@@ -1,0 +1,30 @@
+
+
+#include <Blast/DirectoryExistenceChecker.hpp>
+#include <sys/stat.h>
+
+
+namespace Blast
+{
+
+
+DirectoryExistenceChecker::DirectoryExistenceChecker(std::string directory_name)
+   : directory_name(directory_name)
+{
+}
+
+
+DirectoryExistenceChecker::~DirectoryExistenceChecker()
+{
+}
+
+
+bool DirectoryExistenceChecker::exists()
+{
+struct stat info;
+return stat(directory_name.c_str(), &info) == 0 && S_ISDIR(info.st_mode);
+
+}
+} // namespace Blast
+
+

--- a/tests/Blast/DirectoryCreatorTest.cpp
+++ b/tests/Blast/DirectoryCreatorTest.cpp
@@ -1,0 +1,28 @@
+
+
+#include <gtest/gtest.h>
+
+#include <Blast/DirectoryCreator.hpp>
+
+
+TEST(DirectoryCreatorTest, can_be_created_without_arguments)
+{
+   Blast::DirectoryCreator directory_creator;
+}
+
+
+TEST(DirectoryCreatorTest, exists_returns_true_when_a_directory_is_present)
+{
+   std::string directory_that_should_exist = "quintessence";
+   Blast::DirectoryCreator directory_creator(directory_that_should_exist);
+   ASSERT_TRUE(directory_creator.create());
+}
+
+
+TEST(DirectoryCreatorTest, exists_returns_false_when_attempting_to_creating_multiple_nested_directories)
+{
+   Blast::DirectoryCreator directory_creator("directory_that_does_not_exist/and_has_a_nested_directory/");
+   ASSERT_FALSE(directory_creator.create());
+}
+
+

--- a/tests/Blast/DirectoryExistenceCheckerTest.cpp
+++ b/tests/Blast/DirectoryExistenceCheckerTest.cpp
@@ -1,0 +1,30 @@
+
+
+#include <gtest/gtest.h>
+
+#include <Blast/DirectoryExistenceChecker.hpp>
+
+
+TEST(DirectoryExistenceCheckerTest, can_be_created_without_arguments)
+{
+   Blast::DirectoryExistenceChecker directory_existence_checker;
+}
+
+
+TEST(DirectoryExistenceCheckerTest, exists_returns_true_when_a_directory_is_present)
+{
+   std::string directory_that_should_exist = "quintessence"; // this directory is expected to exist on the filesystem
+                                                             // note that this test executable must be run from the
+                                                             // directory where this expected directory is to be located
+   Blast::DirectoryExistenceChecker directory_existence_checker(directory_that_should_exist);
+   ASSERT_TRUE(directory_existence_checker.exists());
+}
+
+
+TEST(DirectoryExistenceCheckerTest, exists_returns_false_when_a_directory_is_not_present)
+{
+   Blast::DirectoryExistenceChecker directory_existence_checker("directory_that_does_not_exist");
+   ASSERT_FALSE(directory_existence_checker.exists());
+}
+
+


### PR DESCRIPTION
## This PR will:

1. Include the `YAML_CPP_INCLUDE_DIR` directory in the `Makefile`, under the `objects` section.
2. Add a `properties` section in the quintessence.md documentation.
3. Add a `Blast/DirectoryCreator` class
4. Add a `Blast/DirectoryExistenceChecker` class
5. Extend the `quintessence_from_yaml` program

## Changes to the `quintessence_from_yaml`

1. Add ability for default values
2. Add sensible defaults for common dependencies
3. Automatically create directories for namespaces if they're not present